### PR TITLE
Add hassfest validation

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v2"
+        - uses: home-assistant/actions/hassfest@master 

--- a/custom_components/browser_mod/manifest.json
+++ b/custom_components/browser_mod/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "browser_mod",
   "name": "Browser mod",
-  "documentation": "",
+  "documentation": "https://github.com/thomasloven/hass-browser_mod/blob/master/README.md",
   "dependencies": ["websocket_api", "http"],
   "codeowners": [],
   "requirements": []


### PR DESCRIPTION
This will set up GitHub Actions to validate this repo with hassfest on PRs and midnight.

Output: https://github.com/balloob/hass-browser_mod/runs/593886397?check_suite_focus=true