### PR TITLE
fix icons not showing in new frontend version

### DIFF
--- a/custom_components/browser_mod/browser_mod.js
+++ b/custom_components/browser_mod/browser_mod.js
@@ -93,7 +93,9 @@ const e="lovelace-player-device-id";function t(){if(!localStorage[e]){const t=()
             <ha-icon-button
               .icon=${e.muted?"mdi:volume-off":"mdi:volume-high"}
               @click=${this.handleMute}
-            ></ha-icon-button>
+            >
+              <ha-icon .icon=${e.muted?"mdi:volume-off":"mdi:volume-high"}></ha-icon>
+            </ha-icon-button>
             <ha-slider
               min="0"
               max="1"
@@ -108,12 +110,16 @@ const e="lovelace-player-device-id";function t(){if(!localStorage[e]){const t=()
                     .icon=${e.paused?"mdi:play":"mdi:pause"}
                     @click=${this.handlePlayPause}
                     highlight
-                  ></ha-icon-button>
+                  >
+                    <ha-icon .icon=${e.paused?"mdi:play":"mdi:pause"}></ha-icon>
+                  </ha-icon-button>
                 `}
             <ha-icon-button
               .icon=${"mdi:cog"}
               @click=${this.handleMoreInfo}
-            ></ha-icon-button>
+            >
+              <ha-icon .icon=${"mdi:cog"}></ha-icon>
+            </ha-icon-button>
           </div>
 
           <div class="device-id" @click=${this.setDeviceID}>${s}</div>

--- a/js/browser-player.js
+++ b/js/browser-player.js
@@ -75,7 +75,9 @@ Promise.race(bases).then(() => {
             <ha-icon-button
               .icon=${player.muted ? "mdi:volume-off" : "mdi:volume-high"}
               @click=${this.handleMute}
-            ></ha-icon-button>
+            >
+              <ha-icon .icon=${player.muted ? "mdi:volume-off" : "mdi:volume-high"}></ha-icon>
+            </ha-icon-button>
             <ha-slider
               min="0"
               max="1"
@@ -92,12 +94,16 @@ Promise.race(bases).then(() => {
                     .icon=${player.paused ? "mdi:play" : "mdi:pause"}
                     @click=${this.handlePlayPause}
                     highlight
-                  ></ha-icon-button>
+                  >
+                    <ha-icon .icon=${player.paused ? "mdi:play" : "mdi:pause"}></ha-icon>
+                  </ha-icon-button>
                 `}
             <ha-icon-button
               .icon=${"mdi:cog"}
               @click=${this.handleMoreInfo}
-            ></ha-icon-button>
+            >
+              <ha-icon .icon=${"mdi:cog"}></ha-icon>
+            </ha-icon-button>
           </div>
 
           <div class="device-id" @click=${this.setDeviceID}>${deviceID}</div>


### PR DESCRIPTION
Breaking changes made recently to the frontend, specifically in the `ha-icon-button` element, causes some buttons to not show up. This PR fixes that issue while maintaining backward compatibility.
You can see the breaking changes here:

https://github.com/home-assistant/frontend/blob/master/src/components/ha-icon-button.ts#L10-L11

https://github.com/home-assistant/frontend/commit/0c940be5fb002f7df938055997d2be71d6e50903#diff-b7749fac30d4d29a769a04d77d9e72093cfdfecd6e325fba66649575229bde9c

i.e I'm using the latest beta version of HA that was released a couple of hours ago