### PR TITLE
Vertical align x in close button

### DIFF
--- a/custom_components/browser_mod/browser_mod.js
+++ b/custom_components/browser_mod/browser_mod.js
@@ -12,7 +12,7 @@ const e="lovelace-player-device-id";function t(){if(!localStorage[e]){const t=()
                     .label=${"dismiss"}
                     dialogAction="cancel"
                   >
-                    <ha-icon
+                    <ha-icon style="font-size: initial;" 
                       .icon=${"mdi:close"}
                     ></ha-icon>
                   </mwc-icon-button>


### PR DESCRIPTION
Wonder if I'm the only one who wants to have the close X aligned correctly. Had this [PR](https://github.com/thomasloven/hass-browser_mod/pull/225) already in the past, but was ignored and was outdated after a while because of other changes.

Unset font-size in ha-icon to have it not inherited from .mdc-icon-button and then as wanted vertical aligned in the mwc-icon-button.

old: 
![image](https://user-images.githubusercontent.com/22775515/118685544-7c9cde00-b803-11eb-9861-9f3d1da9dcc7.png)

new:
![image](https://user-images.githubusercontent.com/22775515/118685462-655df080-b803-11eb-946b-3867366be858.png)
