### PR TITLE
Change device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/browser_mod/binary_sensor.py
+++ b/custom_components/browser_mod/binary_sensor.py
@@ -50,7 +50,7 @@ class BrowserModSensor(BrowserModEntity):
         return DEVICE_CLASS_MOTION
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             "type": "browser_mod",
             "last_seen": self.last_seen,

--- a/custom_components/browser_mod/camera.py
+++ b/custom_components/browser_mod/camera.py
@@ -37,7 +37,7 @@ class BrowserModCamera(Camera, BrowserModEntity):
         return base64.b64decode(self.data.split(",")[-1])
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             "type": "browser_mod",
             "deviceID": self.deviceID,

--- a/custom_components/browser_mod/light.py
+++ b/custom_components/browser_mod/light.py
@@ -40,7 +40,7 @@ class BrowserModLight(LightEntity, BrowserModEntity):
         return not self.data.get("blackout", False)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             "type": "browser_mod",
             "deviceID": self.deviceID,

--- a/custom_components/browser_mod/media_player.py
+++ b/custom_components/browser_mod/media_player.py
@@ -42,7 +42,7 @@ class BrowserModPlayer(MediaPlayerEntity, BrowserModEntity):
         self.schedule_update_ha_state()
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             "type": "browser_mod",
             "deviceID": self.deviceID,

--- a/custom_components/browser_mod/sensor.py
+++ b/custom_components/browser_mod/sensor.py
@@ -33,7 +33,7 @@ class BrowserModSensor(BrowserModEntity):
         return len(self.connection.connection)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             "type": "browser_mod",
             "last_seen": self.last_seen,


### PR DESCRIPTION
In Home Assistant 2021.4.0 **extra_state_attributes** was introduced as a replacement for **device_state_attributes** (identical parameters, just a name change) but the old name could be used without any warnings being give.

In Home Assistant 2021.12.0 using **device_state_attributes** now results in a warning in the logs.

This PR changes all instances of **device_state_attributes** to **extra_state_attributes**.

Fixes #273