### PR TITLE
Fix for #280 (Can't clean devices due to AttributeError: 'NoneType' object has no attribute 'state')

### DIFF
--- a/custom_components/browser_mod/service.py
+++ b/custom_components/browser_mod/service.py
@@ -83,6 +83,9 @@ async def async_clean_devices(hass, data):
     entities_to_remove = []
     for e in entity_entries:
         entity = hass.states.get(e.entity_id)
+        if e.disabled_by == "integration":
+            entities_to_remove.append(e)
+            continue
         if entity.state != STATE_UNAVAILABLE:
             continue
         if e.device_id in devices_to_keep:


### PR DESCRIPTION
When running service browser_mod.clean_devices it will error out (in home-assistant.log) with;

```
2021-12-23 10:02:00 ERROR (MainThread) [homeassistant.helpers.script.websocket_api_script] websocket_api script: Error executing script. Unexpected error for call_service at pos 1: 'NoneType' object has no attribute 'state'
Traceback (most recent call last):
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 381, in _async_step
    await getattr(self, handler)()
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 584, in _async_call_service_step
    await service_task
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/core.py", line 1495, in async_call
    task.result()
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/core.py", line 1530, in _execute_service
    await handler.job.target(service_call)
  File "/Users/homeassistant/.homeassistant/custom_components/browser_mod/service.py", line 54, in call_service
    await async_clean_devices(hass, service_call.data)
  File "/Users/homeassistant/.homeassistant/custom_components/browser_mod/service.py", line 86, in async_clean_devices
    if entity.state != STATE_UNAVAILABLE:
AttributeError: 'NoneType' object has no attribute 'state'
2021-12-23 10:02:00 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [4858531792] Error handling message: Unknown error
Traceback (most recent call last):
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/components/websocket_api/decorators.py", line 27, in _handle_async_response
    await func(hass, connection, msg)
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/components/websocket_api/commands.py", line 527, in handle_execute_script
    await script_obj.async_run(msg.get("variables"), context=context)
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 1259, in async_run
    await asyncio.shield(run.async_run())
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 363, in async_run
    await self._async_step(log_exceptions=False)
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 381, in _async_step
    await getattr(self, handler)()
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/helpers/script.py", line 584, in _async_call_service_step
    await service_task
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/core.py", line 1495, in async_call
    task.result()
  File "/opt/homeassistant/lib/python3.9/site-packages/homeassistant/core.py", line 1530, in _execute_service
    await handler.job.target(service_call)
  File "/Users/homeassistant/.homeassistant/custom_components/browser_mod/service.py", line 54, in call_service
    await async_clean_devices(hass, service_call.data)
  File "/Users/homeassistant/.homeassistant/custom_components/browser_mod/service.py", line 86, in async_clean_devices
    if entity.state != STATE_UNAVAILABLE:
AttributeError: 'NoneType' object has no attribute 'state'
```

This is due to entity or device being set as "disabled" so it's state cannot be read.
This can be worked around by evaluating "e.disabled_by" and if it's disabled  by Integration it's ok to delete it.