### PR TITLE
Add browser_mod.window_reload to services.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ service: browser_mod.lovelace_reload
 </details>
 
 <details><summary>window_reload</summary>
-Forces the browser to reload the page. Same as clicking your browsers refresh button.
+Forces the browser to reload the page. Same as clicking your browser's refresh button.
 
 > Note: This is not guaranteed to clear the frontend cache.
 

--- a/custom_components/browser_mod/services.yaml
+++ b/custom_components/browser_mod/services.yaml
@@ -115,6 +115,12 @@ lovelace_reload:
     deviceID:
       description: "(optional) List of receiving browsers"
       example: '["99980b13-dabc9563", "office_computer"]'
+window_reload:
+  description: "Forces the browser to reload the page. Same as clicking your browser's refresh button. Note: This is not guaranteed to clear the frontend cache."
+  fields:
+    deviceID:
+      description: "(optional) List of receiving browsers"
+      example: '["99980b13-dabc9563", "office_computer"]'
 delay:
   description: "Do nothing for a while"
   fields:


### PR DESCRIPTION
Without this, Home Assistant's dev tools service call UI doesn't show the YAML editor one uses to drop in the `deviceID` parameter.