### PR TITLE
Change camera_image to include a width and height

### DIFF
--- a/custom_components/browser_mod/camera.py
+++ b/custom_components/browser_mod/camera.py
@@ -33,7 +33,7 @@ class BrowserModCamera(Camera, BrowserModEntity):
             self.last_seen = datetime.now()
         self.schedule_update_ha_state()
 
-    def camera_image(self):
+    def camera_image(self, width=None, height=None):
         return base64.b64decode(self.data.split(",")[-1])
 
     @property


### PR DESCRIPTION
This is a fix/workaround for breaking change introduced in
- https://github.com/home-assistant/core/pull/53835
- https://github.com/home-assistant/core/pull/68039

With this update camera entity will work again.