### PR TITLE
mobile popup fix for HA 2023.7.3

### DIFF
--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -386,10 +386,8 @@ class BrowserModPopup extends LitElement {
         ha-dialog {
           --mdc-dialog-min-width: 97vw;
           --mdc-dialog-max-width: 97vw;
-          --mdc-dialog-min-height: 100%;
-          --mdc-dialog-max-height: 100%;
-          --vertical-align-dialog: flex-end;
-          --ha-dialog-border-radius: 0;
+          --vertical-align-dialog: flex-start;
+          --ha-dialog-border-radius: var(--popup-border-radius, 28px);
         }
         :host([wide]) .content {
           width: 100vw;


### PR DESCRIPTION
#606 #617
Around 2023.7.3 mobile popups got really longgggg.
Happens for iOS, android, and web browser.

![fix](https://github.com/thomasloven/hass-browser_mod/assets/124423639/04b7331e-ca52-4f5d-8f1e-4deeb0ec45c1)
