### PR TITLE
fix toolbar not fullscreen if hideSidebar is true

### DIFF
--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -60,7 +60,7 @@ export const AutoSettingsMixin = (SuperClass) => {
       if (settings.hideSidebar === true) {
         selectTree(
           document.body,
-          "home-assistant $ home-assistant-main $ ha-drawer"
+          "home-assistant $ home-assistant-main"
         ).then((el) => el?.style?.setProperty("--mdc-drawer-width", "0px"));
         selectTree(
           document.body,


### PR DESCRIPTION
If you activate "hideSidebar" but not hideHeader, the header will not be fullscreen.

This is fixed in this PR by setting the 0px with for the drawer on a different element. 

Do you like me to commit the build file, too?