### PR TITLE
Use MediaplayerEntityFeature and MediaType enums

### DIFF
--- a/custom_components/browser_mod/media_player.py
+++ b/custom_components/browser_mod/media_player.py
@@ -1,23 +1,11 @@
 from homeassistant.components import media_source
-from homeassistant.components.media_player import (
-    SUPPORT_PLAY,
-    SUPPORT_PLAY_MEDIA,
-    SUPPORT_PAUSE,
-    SUPPORT_STOP,
-    SUPPORT_VOLUME_SET,
-    SUPPORT_VOLUME_MUTE,
-    MediaPlayerEntity,
-)
+from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_MUSIC,
-    MEDIA_TYPE_URL,
-    SUPPORT_BROWSE_MEDIA,
-    SUPPORT_SEEK,
-    SUPPORT_TURN_OFF,
-    SUPPORT_TURN_ON,
+    MediaPlayerEntityFeature, 
+    MediaType,
 )
 from homeassistant.const import (
     STATE_UNAVAILABLE,
@@ -74,16 +62,16 @@ class BrowserModPlayer(BrowserModEntity, MediaPlayerEntity):
     @property
     def supported_features(self):
         return (
-            SUPPORT_PLAY
-            | SUPPORT_PLAY_MEDIA
-            | SUPPORT_PAUSE
-            | SUPPORT_STOP
-            | SUPPORT_VOLUME_SET
-            | SUPPORT_VOLUME_MUTE
-            | SUPPORT_BROWSE_MEDIA
-            | SUPPORT_SEEK
-            | SUPPORT_TURN_OFF
-            | SUPPORT_TURN_ON
+            MediaPlayerEntityFeature.PLAY
+            | MediaPlayerEntityFeature.PLAY_MEDIA
+            | MediaPlayerEntityFeature.PAUSE
+            | MediaPlayerEntityFeature.STOP
+            | MediaPlayerEntityFeature.VOLUME_SET
+            | MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.BROWSE_MEDIA
+            | MediaPlayerEntityFeature.SEEK
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.TURN_ON
         )
 
     @property
@@ -122,7 +110,7 @@ class BrowserModPlayer(BrowserModEntity, MediaPlayerEntity):
             media_type = play_item.mime_type
             media_id = play_item.url
             media_id = async_process_play_media_url(self.hass, media_id)
-        if media_type in (MEDIA_TYPE_URL, MEDIA_TYPE_MUSIC):
+        if media_type in (MediaType.URL, MediaType.MUSIC):
             media_id = async_process_play_media_url(self.hass, media_id)
         await self.browser.send(
             "player-play", media_content_id=media_id, media_type=media_type, **kwargs


### PR DESCRIPTION
I updated to 2024.1 and could not browse media for my browser_mod media players. These updates got it back working.