### PR TITLE
Fix "Detected that custom integration 'browser_mod' accesses hass.hel…

### DIFF
--- a/custom_components/browser_mod/store.py
+++ b/custom_components/browser_mod/store.py
@@ -1,5 +1,6 @@
 import logging
 import attr
+from homeassistant.helpers.storage import Store
 
 STORAGE_VERSION = 1
 STORAGE_KEY = "browser_mod.storage"
@@ -91,7 +92,7 @@ class ConfigStoreData:
 
 class BrowserModStore:
     def __init__(self, hass):
-        self.store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self.store = Store(hass, STORAGE_VERSION, STORAGE_KEY)
         self.listeners = []
         self.data = None
         self.dirty = False


### PR DESCRIPTION
…pers.storage. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from storage directly at custom_components/browser_mod/store.py, line 94: self.store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY), please report it to the author of the 'browser_mod' custom integration"