### PR TITLE
add media_content_id

### DIFF
--- a/custom_components/browser_mod/media_player.py
+++ b/custom_components/browser_mod/media_player.py
@@ -93,6 +93,10 @@ class BrowserModPlayer(BrowserModEntity, MediaPlayerEntity):
         return float(position) if position is not None else None
 
     @property
+    def media_content_id(self):
+        return self._data.get("player", {}).get("src", None)
+
+    @property
     def media_position_updated_at(self):
         return dt.utcnow()
 


### PR DESCRIPTION
In V2 apparently the media_content_id was missing.

This can be handy if you want to use it with a automation. for instance an announcement.
