### PR TITLE
Address lovelace_data resources deprecation warning

### DIFF
--- a/custom_components/browser_mod/mod_view.py
+++ b/custom_components/browser_mod/mod_view.py
@@ -56,7 +56,7 @@ async def async_setup_view(hass: HomeAssistant):
     )
 
     # Also load Browser Mod as a lovelace resource so it's accessible to Cast
-    resources = hass.data["lovelace"]["resources"]
+    resources = hass.data["lovelace"].resources
     if resources:
         if not resources.loaded:
             await resources.async_load()


### PR DESCRIPTION
Fixes deprecation warning described in #798 and #796:

> Detected that custom integration 'browser_mod' accessed lovelace_data['resources'] instead of lovelace_data.resources at custom_components/browser_mod/mod_view.py, line 59: resources = hass.data["lovelace"]["resources"]. This will stop working in Home Assistant 2026.2, please report it to the author of the 'browser_mod' custom integration
