### PR TITLE
Allow store to handle unknown values after, for example, downgrade

### DIFF
--- a/custom_components/browser_mod/store.py
+++ b/custom_components/browser_mod/store.py
@@ -27,7 +27,9 @@ class SettingsStoreData:
 
     @classmethod
     def from_dict(cls, data):
-        return cls(**data)
+        class_attributes = attr.fields_dict(cls).keys()
+        valid = {key: value for key, value in data.items() if key in class_attributes}
+        return cls(**valid)
 
     def asdict(self):
         return attr.asdict(self)
@@ -44,10 +46,12 @@ class BrowserStoreData:
 
     @classmethod
     def from_dict(cls, data):
+        class_attributes = attr.fields_dict(cls).keys()
+        valid = {key: value for key, value in data.items() if key in class_attributes}
         settings = SettingsStoreData.from_dict(data.get("settings", {}))
         return cls(
             **(
-                data
+                valid
                 | {
                     "settings": settings,
                 }


### PR DESCRIPTION
When working on recent versions after 'saveScreenState' was added to store state, I noticed that reverting version, Browser Mod would error and not load. This PR will protect from this in the future, allowing downgrade to a version after this PR is merged.