### PR TITLE
Show notification when Browser JS Version does not match component version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ What if you could tap a button and have Home Assistant ask you which rooms you w
 
 - Restart Home Assistant
 
+# Upgrading
+
+- Upgrade via [HACS](https://hacs.xyz) or copy new contents of `custom_components/browser_mod/` to `<your config dir>/custom_components/browser_mod/`.
+
+- Restart Home Assistant. If you are upgrading via [HACS](https://hacs.xyz) you will get a repair item to restart Home Assistant.
+
+- After restarting Home Assistant, all Browsers will need a reload to download the latest version of Browser Mod javascript file. Version 2.4.0 includes a notification when a Browser version mismatch is detected, so from 2.4.x onwards simply clicking __Reload__ should be sufficient. If you keep getting the notification, you may need to do a hard Browser reload `SHIFT+F5` or in some cases clear your Browser cache.
+
 > Note: If you are upgrading from Browser Mod 1, it is likely that you will get some errors in your log during a transition period. They will say something along the lines of `Error handling message: extra keys not allowed @ data['deviceID']`.
 >
 > They appear when a browser which has an old version of Browser Mod cached tries to connect and should disappear once you have cleared all your caches properly.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ What if you could tap a button and have Home Assistant ask you which rooms you w
 
 - Restart Home Assistant. If you are upgrading via [HACS](https://hacs.xyz) you will get a repair item to restart Home Assistant.
 
-- After restarting Home Assistant, all Browsers will need a reload to download the latest version of Browser Mod javascript file. Version 2.4.0 includes a notification when a Browser version mismatch is detected, so from 2.4.x onwards simply clicking __Reload__ should be sufficient. If you keep getting the notification, you may need to do a hard Browser reload `SHIFT+F5` or in some cases clear your Browser cache.
+- After restarting Home Assistant, all Browsers will need a reload to download the latest version of Browser Mod javascript file. Version 2.4.0 includes a notification when a Browser version mismatch is detected, so from 2.4.x onwards simply clicking __Reload__ should be sufficient. If you keep getting the notification, you may need to do a hard Browser reload `SHIFT+F5` or in some cases [clear your Browser cache](https://github.com/thomasloven/hass-config/wiki/Clearing-your-browser-cache).
 
 > Note: If you are upgrading from Browser Mod 1, it is likely that you will get some errors in your log during a transition period. They will say something along the lines of `Error handling message: extra keys not allowed @ data['deviceID']`.
 >

--- a/custom_components/browser_mod/__init__.py
+++ b/custom_components/browser_mod/__init__.py
@@ -7,6 +7,7 @@ from .mod_view import async_setup_view
 from .connection import async_setup_connection
 from .const import DOMAIN, DATA_BROWSERS, DATA_ADDERS, DATA_STORE
 from .service import async_setup_services
+from .helpers import get_version
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,6 +26,9 @@ async def async_setup(hass, config):
 
     store = BrowserModStore(hass)
     await store.load()
+
+    version = await hass.async_add_executor_job(get_version, hass)
+    await store.set_version(version)
 
     hass.data[DOMAIN] = {
         DATA_BROWSERS: {},

--- a/custom_components/browser_mod/helpers.py
+++ b/custom_components/browser_mod/helpers.py
@@ -1,0 +1,7 @@
+import json
+from homeassistant.core import HomeAssistant
+
+def get_version(hass: HomeAssistant):
+    with open(hass.config.path("custom_components/browser_mod/manifest.json"), "r") as fp:
+        manifest = json.load(fp)
+        return manifest["version"]

--- a/custom_components/browser_mod/mod_view.py
+++ b/custom_components/browser_mod/mod_view.py
@@ -1,19 +1,14 @@
-import json
 from homeassistant.core import HomeAssistant
 from homeassistant.components.frontend import add_extra_js_url, async_register_built_in_panel
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.lovelace.resources import ResourceStorageCollection
 
 from .const import FRONTEND_SCRIPT_URL, SETTINGS_PANEL_URL
+from .helpers import get_version
 
 import logging
 
 _LOGGER = logging.getLogger(__name__)
-
-def get_version(hass: HomeAssistant):
-    with open(hass.config.path("custom_components/browser_mod/manifest.json"), "r") as fp:
-        manifest = json.load(fp)
-        return manifest["version"]
 
 async def async_setup_view(hass: HomeAssistant):
 

--- a/custom_components/browser_mod/store.py
+++ b/custom_components/browser_mod/store.py
@@ -129,6 +129,14 @@ class BrowserModStore:
 
         return remove_listener
 
+    def get_version(self):
+        return self.data.version
+
+    async def set_version(self, version):
+        if self.data.version != version:
+            self.data.version = version
+            await self.updated()
+
     def get_browser(self, browserID):
         return self.data.browsers.get(browserID, BrowserStoreData())
 

--- a/js/plugin/main.ts
+++ b/js/plugin/main.ts
@@ -16,18 +16,21 @@ import pjson from "../../package.json";
 import "./popup-card";
 import { AutoSettingsMixin } from "./frontend-settings";
 import { BrowserIDMixin } from "./browserID";
+import { VersionMixin } from "./version.js";
 
 export class BrowserMod extends ServicesMixin(
-  PopupMixin(
-    ActivityMixin(
-      BrowserStateMixin(
-        CameraMixin(
-          MediaPlayerMixin(
-            ScreenSaverMixin(
-              AutoSettingsMixin(
-                FullyMixin(
-                  RequireInteractMixin(
-                    ConnectionMixin(BrowserIDMixin(EventTarget))
+  VersionMixin(
+    PopupMixin(
+      ActivityMixin(
+        BrowserStateMixin(
+          CameraMixin(
+            MediaPlayerMixin(
+              ScreenSaverMixin(
+                AutoSettingsMixin(
+                  FullyMixin(
+                    RequireInteractMixin(
+                      ConnectionMixin(BrowserIDMixin(EventTarget))
+                    )
                   )
                 )
               )

--- a/js/plugin/version.ts
+++ b/js/plugin/version.ts
@@ -1,0 +1,61 @@
+import pjson from "../../package.json";
+import { selectTree } from "../helpers";
+
+export const VersionMixin = (SuperClass) => {
+  return class VersionMixinClass extends SuperClass {
+    _version: string;
+    _notificationPending: boolean = false;
+
+    constructor() {
+      super();
+      this._version = pjson.version;
+      this.addEventListener("browser-mod-connected", async () => {
+        await this._checkVersion();
+      });
+      this.addEventListener("browser-mod-disconnected", () => {
+        this._notificationPending = false;
+      });
+    }
+
+    async _checkVersion() {
+      if (this._data?.version && this._data.version !== this._version) {
+        if (!this._notificationPending) {
+          this._notificationPending = true;
+          await this._loaclNotification(
+            this._data.version,
+            this._version
+          )
+        }
+      }
+    }
+
+    async _loaclNotification(serverVersion, clientVersion) {
+      // Wait for any other notifications to expire
+      let haToast;
+      do {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        haToast = await selectTree(
+                document.body,
+                "home-assistant $ notification-manager $ ha-toast",
+                false,
+                1000)
+      } while (haToast);
+      const service = "browser_mod.notification";
+      const message = `Browser Mod version mismatch! Browser: ${clientVersion}, Home Assistant: ${serverVersion}`;
+      const data = {
+        message: message,
+        duration: -1, // 60 seconds
+        dismissable: true,
+        action_text: "Reload",
+        browser_id: "THIS",
+        action: {
+          service: "browser_mod.refresh",
+          data: {
+            browser_id: "THIS",
+          },
+        },
+      }
+      await this.service(service, data);
+    }
+  };
+};

--- a/js/plugin/version.ts
+++ b/js/plugin/version.ts
@@ -9,7 +9,7 @@ export const VersionMixin = (SuperClass) => {
     constructor() {
       super();
       this._version = pjson.version;
-      this.addEventListener("browser-mod-connected", async () => {
+      this.addEventListener("browser-mod-ready", async () => {
         await this._checkVersion();
       });
       this.addEventListener("browser-mod-disconnected", () => {


### PR DESCRIPTION
Rationale for PR. As Browser Mod is an integration, HACS will not prompt for Browser reload like it does for a Dashboard plugin. Hence after HA restart, even the Browser used for updating will be running the previous client JS. Also, as there are many installation using many 'always on' Browser devices, it would be good for those devices to show a notification as they will be in the same state after a Browser Mod upgrade.