### PR TITLE
Add Default action as a Frontend Setting

### DIFF
--- a/custom_components/browser_mod/store.py
+++ b/custom_components/browser_mod/store.py
@@ -15,6 +15,7 @@ class SettingsStoreData:
     hideSidebar = attr.ib(type=bool, default=None)
     hideHeader = attr.ib(type=bool, default=None)
     defaultPanel = attr.ib(type=str, default=None)
+    defaultAction = attr.ib(type=object, default=None)
     sidebarPanelOrder = attr.ib(type=list, default=None)
     sidebarHiddenPanels = attr.ib(type=list, default=None)
     sidebarTitle = attr.ib(type=str, default=None)

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -93,7 +93,41 @@ This will hide the header bar. Completely. It does not care if there are useful 
 
 Set the default dashboard that is shown when you access `https://<your home assistant url>/` with nothing after the `/`.
 
-> *Note:* This also of works with other pages than lovelace dashboards, like e.g. `logbook` or even `history?device_id=f112fd806f2520c76318406f98cd244e&start_date=2022-09-02T16%3A00%3A00.000Z&end_date=2022-09-02T19%3A00%3A00.000Z`.
+> *Note:* 
+>1. This option sets the same local setting as Home Assistants' Dashboard setting in User Settings. If this setting does not provide exactly what you are after you may wish to use a Default action with `browser_mod.navigate`.
+>2. This also of works with other pages than lovelace dashboards, like e.g. `logbook` or even `history?device_id=f112fd806f2520c76318406f98cd244e&start_date=2022-09-02T16%3A00%3A00.000Z&end_date=2022-09-02T19%3A00%3A00.000Z`.
+
+### Default action
+
+Set the default action to be run when Browser is loaded or refreshed. This setting accepts the same action Config as per `browser_mod.popup` actions. For more information see the examples actions included in [Actionable popups](./popups.md#actionable-popups). If you are using Browser Mod [SERVICES](./services.md), in most cases you would omit `browser_id` or `user_id` so the service runs on the loading Browser.
+
+__IMPORTANT__: Like actions popups and notifications, this setting DOES NOT support templates. 
+
+*Tips:*
+1. Multiple actions can be called by using a list of actions. These are called in parallel, matching actions for popups and notifications.
+```yaml
+- action: browser_mod.navigate
+  data:
+    path: /my-dashboard/second-view
+- action: browser_mod.notification
+  data:
+    message: Good Morning Dave
+```
+2. For fine grained control of timing, consider using `browser_mod.sequence`. Note here that only one top level action is used.
+```yaml
+action: browser_mod.sequence
+data:
+  sequence:
+    - service: browser_mod.navigate
+      data:
+        path: /my-dashboard/second-view
+    - service: browser_mod.delay
+      data:
+        time: 5000
+    - service: browser_mod.notification
+      data:
+        message: Good Morning Dave
+```
 
 ### Sidebar order
 

--- a/js/config_panel/browser-mod-settings-table.ts
+++ b/js/config_panel/browser-mod-settings-table.ts
@@ -195,7 +195,7 @@ class BrowserModSettingsTable extends LitElement {
     for (const [k, v] of Object.entries(settings.user)) {
       const user = users.find((usr) => usr.id === k);
       if (!user) continue;
-      let val = String(v);
+      let val = (typeof(v) === "object") ? "Config" : String(v);
       if (val.length >= 20) val = val.slice(0, 20) + "...";
       data.push({
         name: `User: ${user.name}`,
@@ -224,7 +224,7 @@ class BrowserModSettingsTable extends LitElement {
     });
 
     for (const [k, v] of Object.entries(settings.browser)) {
-      let val = String(v);
+      let val = (typeof(v) === "object") ? "Config" : String(v);
       if (val.length >= 20) val = val.slice(0, 20) + "...";
       data.push({
         name: `Browser: ${k}`,
@@ -256,7 +256,7 @@ class BrowserModSettingsTable extends LitElement {
       name: "GLOBAL",
       value:
         settings.global != null
-          ? String(settings.global)
+          ?  ((typeof(settings.global) === "object") ? "Config" : String(settings.global))
           : html`<span style="color: var(--warning-color);">DEFAULT</span>`,
       controls: html`
         <div>

--- a/js/config_panel/frontend-settings-card.ts
+++ b/js/config_panel/frontend-settings-card.ts
@@ -192,6 +192,19 @@ class BrowserModFrontendSettingsCard extends LitElement {
           </ha-expansion-panel>
 
           <ha-expansion-panel
+            .header=${"Default action"}
+            .secondary=${`Home Assistant action that executes when broweser is opened or refreshed.`}
+            leftChevron
+          >
+            <browser-mod-settings-table
+              .hass=${this.hass}
+              .settingKey=${"defaultAction"}
+              .settingSelector=${{ object: {} }}
+              .default=${ {} }
+            ></browser-mod-settings-table>
+          </ha-expansion-panel>
+
+          <ha-expansion-panel
             .header=${"Sidebar order"}
             .secondary=${"Order and visibility of sidebar items."}
             leftChevron

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -33,6 +33,8 @@ export const AutoSettingsMixin = (SuperClass) => {
       });
 
       window.addEventListener("location-changed", runUpdates);
+
+      this.addEventListener("browser-mod-connected", this._runDefaultAction, {once: true});
     }
 
     async _auto_settings_setup() {
@@ -200,6 +202,24 @@ export const AutoSettingsMixin = (SuperClass) => {
         return true;
       }
       return false;
+    }
+
+    _runDefaultAction() {
+      if (this.settings.defaultAction) {
+        var action_action = this.settings.defaultAction;
+        if (!Array.isArray(action_action)) {
+          action_action = [action_action];
+        }
+        action_action.forEach(async (actionItem) => {
+          var { action, service, target, data } = actionItem;
+          service = action ?? service;
+          this._service_action({
+            service,
+            target,
+            data: data,
+          });
+        })
+      }
     }
 
     getSetting(key) {


### PR DESCRIPTION
Rationale: Home Assistant Default Dashboard setting, for which there is a Browser Mod Frontend setting, is quite limited and does not work in all cases as you have to Browse to the base URL. Also, there have been requests for various actions on Browser load #792 #742 #667 #664. As you see, lots of requests can be solved by a Default action. See documentation changes in PR for example Default actions.