### PR TITLE
Refine (Re)Connection based on testing combined 2.4.0 code base.

### DIFF
--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -7,6 +7,7 @@ export const ConnectionMixin = (SuperClass) => {
     public ready = false;
 
     private _data;
+    private _connected = false;
     private _connectionResolve;
 
     public connectionPromise = new Promise((resolve) => {
@@ -19,10 +20,12 @@ export const ConnectionMixin = (SuperClass) => {
       const dt = new Date();
       console.log(`${dt.toLocaleTimeString()}`, ...args);
 
-      this.connection.sendMessage({
-        type: "browser_mod/log",
-        message: args[0],
-      });
+      if (this._connected) {
+        this.connection.sendMessage({
+          type: "browser_mod/log",
+          message: args[0],
+        });
+      }
     }
 
     // Propagate internal browser event
@@ -39,22 +42,30 @@ export const ConnectionMixin = (SuperClass) => {
     // Component and frontend are mutually ready
     private onReady = () => {
       this.ready = true;
+      this.LOG("Integration ready: browser_mod loaded and update received");
       this.fireBrowserEvent("browser-mod-ready");
       window.setTimeout(() => this.sendUpdate({}), 1000);
+    }
+
+    // WebSocket has connected
+    private onConnected = () => {
+      this._connected = true;
+      this.LOG("WebSocket connected");
     }
 
     // WebSocket has disconnected
     private onDisconnected = () => {
       this.ready = false;
+      this._connected = false;
+      this.LOG("WebSocket disconnected");
       this.fireBrowserEvent("browser-mod-disconnected");
     }
 
     // Handle incoming message
     private incoming_message(msg) {
-      // Check for readiness (of component and browser)
-      if (!this.ready) {
-        this.LOG("Integration ready: WebSocket connected and browser_mod loaded");
-        this.onReady();
+      // Set that have a connection. Allows logging
+      if (!this._connected) {
+        this.onConnected();
       }
       // Handle messages
       if (msg.command) {
@@ -82,6 +93,10 @@ export const ConnectionMixin = (SuperClass) => {
       if (!this.registered && this.global_settings["autoRegister"] === true)
         this.registered = true;
 
+      // Check for readiness (of component and browser)
+      if (!this.ready) {
+        this.onReady();
+      }
       this.fireBrowserEvent("browser-mod-config-update");
 
       if (update) this.sendUpdate({});
@@ -112,14 +127,14 @@ export const ConnectionMixin = (SuperClass) => {
 
       // Keep connection status up to date
       conn.addEventListener("ready", () => {
-        this.onReady();
+        this.onConnected();
       });
       conn.addEventListener("disconnected", () => {
         this.onDisconnected();
       });
       window.addEventListener("connection-status", (ev: CustomEvent) => {
         if (ev.detail === "connected") {
-          this.onReady();
+          this.onConnected();
         }
         if (ev.detail === "disconnected") {
           this.onDisconnected();
@@ -248,13 +263,18 @@ export const ConnectionMixin = (SuperClass) => {
       if (!this.ready || !this.registered) return;
 
       const dt = new Date();
-      this.LOG("Send:", data);
 
-      this.connection.sendMessage({
-        type: "browser_mod/update",
-        browserID: this.browserID,
-        data,
-      });
+      try {
+        this.LOG("Send:", data);
+        this.connection.sendMessage({
+          type: "browser_mod/update",
+          browserID: this.browserID,
+          data,
+        })
+      } catch (err) {
+        // As we are not sure of connection state, just log to console
+        console.log("Browser Mod: Error sending update:", err);
+      }
     }
 
     browserIDChanged(oldID, newID) {

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -34,7 +34,7 @@ export const AutoSettingsMixin = (SuperClass) => {
 
       window.addEventListener("location-changed", runUpdates);
 
-      this.addEventListener("browser-mod-config-update", this._runDefaultAction, {once: true});
+      this.addEventListener("browser-mod-ready", this._runDefaultAction, {once: true});
     }
 
     async _auto_settings_setup() {


### PR DESCRIPTION
RATIONALE: Upon testing 2.4.0 code base I noted a change to when `browser-mod-ready` (old `browser-mod-connected`) was being fired in that `this.settings` was not available as before. This was due to the change of moving the `ready` event from `update_config` to `incoming_message`. However, we are only indeed __ready__ once we have a config, which many mixins rely on via accessing `settings` via getter or `this._data.settings`. So I have refined the connection code to cater for this, plus reverted back now to using `browser-mod-ready` for the new Default update feature.

@cadavre please review. In the mean time I will put a testing delay in component load to effectively test the original issue in my test environment (currently too fast). You will note that I hastily deleted the v2.4.0-beta.3 release as soon as I saw the need for this refinement. Thank you.