### PR TITLE
Fix breaking old style action: call-service for _action config.

### DIFF
--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -212,8 +212,7 @@ export const AutoSettingsMixin = (SuperClass) => {
         }
         action_action.forEach(async (actionItem) => {
           var { action, service, target, data } = actionItem;
-          action = (action === "call-service" && service) || action;
-          service = action ?? service;
+          service = (action === undefined || action === "call-service") ? service : action;
           this._service_action({
             service,
             target,

--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -85,8 +85,7 @@ export const ServicesMixin = (SuperClass) => {
                 }
                 actions.forEach((actionItem) => {
                   var { action, service, target, data } = actionItem as any;
-                  action = (action === "call-service" && service) || action;
-                  service = action ?? service;
+                  service = (action === undefined || action === "call-service") ? service : action;
                   this._service_action({
                     service,
                     target,
@@ -115,8 +114,7 @@ export const ServicesMixin = (SuperClass) => {
                   }
                   action_action.forEach((actionItem) => {
                     var { action, service, target, data } = actionItem;
-                    action = (action === "call-service" && service) || action;
-                    service = action ?? service;
+                    service = (action === undefined || action === "call-service") ? service : action;
                     this._service_action({
                       service,
                       target,


### PR DESCRIPTION
Allows old style, after this style broke with changes in 2.3.6

```yaml
    action: call-service
    service: light.toggle
    data:
      entity_id: light.bed_light
```

fixes #869. This issue was closed by user with workaround, but there will likely be others waiting to upgrade that will be caught by this issue.