### PR TITLE
Changes for sidebar settings to suit Core Version 2025.6

### DIFF
--- a/js/config_panel/browser-mod-settings-table.ts
+++ b/js/config_panel/browser-mod-settings-table.ts
@@ -6,14 +6,14 @@ let _users = undefined;
 
 class BrowserModSettingsTable extends LitElement {
   @property() settingKey;
-  @property() settingSelector = {
-    template: {},
+  @property() settingSelector: any = {
+    template: {}
   };
 
   @property() hass;
   @property() default;
 
-  @property() tableData = [];
+  @property() tableData = <any>[];
 
   firstUpdated() {
     window.browser_mod.addEventListener("browser-mod-config-update", () =>
@@ -72,7 +72,16 @@ class BrowserModSettingsTable extends LitElement {
     );
   }
 
-  changeSetting(type, target) {
+  async changeSetting(type, target) {
+    if ((this.settingSelector as any).custom) {
+      const allUsers = await this.fetchUsers();
+      (this.settingSelector as any).custom?.changeSetting(type, target, allUsers);
+    } else {
+      this.changeSettingForm(type, target);
+    }
+  }
+
+  changeSettingForm(type, target) {
     const changeSettingCallback = async (newValue) => {
       if (this.settingKey === "sidebarPanelOrder") {
         const sideBar: any = await selectTree(

--- a/js/config_panel/sidebar-settings-custom-selector.ts
+++ b/js/config_panel/sidebar-settings-custom-selector.ts
@@ -1,0 +1,205 @@
+import { selectTree, provideHass, hass_base_el } from "../helpers";
+
+export class SidebarSettingsCustomSelector {
+  _dialogAvaliable: boolean;
+  _dialogEditSidebar: any;
+  _type: string;
+  _target: string;
+  _allUsers: Array<any>;
+  
+  constructor() {
+    if (customElements.get("dialog-edit-sidebar")) {
+        this._dialogAvaliable = true;
+        return;
+    }
+    this._dialogAvaliable = false;
+    selectTree(
+      document.body,
+      "home-assistant $ home-assistant-main $ ha-drawer ha-sidebar"
+    ).then((sidebar) => {
+      // Home Assistant 2025.6 removed editMode from sidebar
+      // so this is the best check to see if sidebar settings dialog is available
+      if (sidebar && sidebar.editMode === undefined) {
+        const menu = sidebar.shadowRoot.querySelector("div.menu");
+        if (menu) {
+          // Simulate hold press on the menu to open the sidebar settings dialog.
+          // Listen once and stop propagation of the show-dialog event
+          // so the dialogImport can be called to make <dialog-edit-sidebar> available
+          // An event method would be nice HA Team!
+          sidebar.addEventListener("show-dialog", (ev) => {
+            if (ev.detail?.dialogTag === "dialog-edit-sidebar") {
+              ev.stopPropagation();
+              ev.detail?.dialogImport?.();
+            }
+          }, {once: true});
+          menu.dispatchEvent(new CustomEvent("action", { detail: { action: "hold" } }));
+        }
+      }
+    });
+    customElements.whenDefined("dialog-edit-sidebar").then(() => {
+      this._dialogAvaliable = true;
+    });
+  }
+    
+  get dialogAvaliable() {
+    return this._dialogAvaliable;
+  }
+
+  get order() {
+    const sidebarPanelOrder = window.browser_mod?.getSetting?.('sidebarPanelOrder');
+    const order =
+      (this._type === "global" ? sidebarPanelOrder.global || '[]' : sidebarPanelOrder[this._type][this._target] || '[]'); 
+    return order;
+  }
+
+  get hidden() {
+    const sidebarHiddenPanels = window.browser_mod?.getSetting?.('sidebarHiddenPanels');
+    const hidden =
+      (this._type === "global" ? sidebarHiddenPanels.global || '[]': sidebarHiddenPanels[this._type][this._target] || '[]'); 
+    return hidden;
+  }   
+
+  async setupDialog() {
+    if (!this._dialogAvaliable) return;
+    this._dialogEditSidebar = document.createElement("dialog-edit-sidebar");
+    const base = await hass_base_el();
+    if (base && this._dialogEditSidebar) {
+      await provideHass(this._dialogEditSidebar);
+      this._dialogEditSidebar._order = JSON.parse(this.order);
+      this._dialogEditSidebar._hidden = JSON.parse(this.hidden);
+      base.shadowRoot.appendChild(this._dialogEditSidebar);
+      this._dialogEditSidebar._open = true;
+      this._dialogEditSidebar.focus();
+      window.addEventListener("popstate", async (ev) => {
+        const sidebarSettingsCustomSelectorState = ev.state?.sidebarSettingsCustomSelector;
+        if (sidebarSettingsCustomSelectorState) {
+          if (!sidebarSettingsCustomSelectorState.open) {
+            if (this._dialogEditSidebar?._open)
+              await this._dialogEditSidebar.closeDialog();
+          }
+        }
+      });
+      if (history.state?.sidebarSettingsCustomSelector === undefined) {
+        history.replaceState(
+          {
+            sidebarSettingsCustomSelector: {
+              open: false,
+            },
+          },
+          ""
+        );
+      }
+      history.pushState(
+        {
+          sidebarSettingsCustomSelector: {
+            open: true,
+          },
+        },
+        ""
+      );
+      this._dialogEditSidebar.addEventListener("dialog-closed", (ev) => {
+        if (ev.detail?.dialog == "dialog-edit-sidebar" && this._dialogEditSidebar) {
+          this._dialogEditSidebar.remove();
+          this._dialogEditSidebar = undefined;
+        }
+      });
+    }
+  }
+
+  async customiseDialog() {
+    if (!this._dialogEditSidebar) return;
+    let haMdDialog;
+    let cnt = 0;
+    while (!haMdDialog && cnt++ < 5) {
+      haMdDialog = this._dialogEditSidebar.shadowRoot.querySelector("ha-md-dialog");
+      if (!haMdDialog) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    }
+    const dialogHeader = await selectTree(
+      this._dialogEditSidebar.shadowRoot,
+      "ha-md-dialog ha-dialog-header",
+    );
+    if (dialogHeader) {
+      const styleEl = document.createElement("style");
+      dialogHeader.shadowRoot.append(styleEl);
+      const typeText = (this._type === "global") ? "Global" : this._type.charAt(0).toUpperCase() + this._type.slice(1) + " - ";
+      let targetText = "";
+      if (this._type === "user") {
+        for (const user of this._allUsers) {
+          if (user.id === this._target) {
+            targetText = user.name;
+            break;
+          }
+        }
+      } else {
+        targetText = this._target ?? "";
+      }
+      // Hide subtitle message about sync
+      // Append Browser Mod details using ::after CSS styling
+      styleEl.innerHTML = `
+        .header-subtitle {
+          display: none;
+        }
+        .header-title::after {
+          content: "- ${typeText}${targetText}";
+        }
+      `;
+    }
+  }
+
+  async setupSaveHandler() {
+    if (!this._dialogEditSidebar) return;
+    const haButtonSave = this._dialogEditSidebar.shadowRoot.querySelector(
+        '[slot="actions"] > ha-button:nth-child(2)');   
+    if (haButtonSave) {
+      const buttonSave = haButtonSave.shadowRoot.querySelector("button");
+      if (buttonSave) {
+        buttonSave.addEventListener("click", (ev) => {
+          ev.stopImmediatePropagation();
+          ev.stopPropagation();
+          ev.preventDefault();
+          this._dialogEditSidebar.dispatchEvent(new CustomEvent("sidebar-settings-save"));
+        });
+      }
+    } 
+  }
+
+  async saveSettings() {
+    if (!this._dialogEditSidebar) return;
+
+    const order = this._dialogEditSidebar._order;
+    const hidden = this._dialogEditSidebar._hidden;
+
+    window.browser_mod.setSetting(this._type, this._target, {
+        sidebarHiddenPanels: JSON.stringify(hidden),
+        sidebarPanelOrder: JSON.stringify(order),
+    });
+
+    this._dialogEditSidebar.closeDialog();
+  }
+
+  async changeSetting(type, target, allUsers) {
+    if (!this.dialogAvaliable) {
+      window.browser_mod?.showPopup?.(
+        "ERROR!",
+        "Sidebar settings dialog unavailable.",
+        {
+            right_button: "OK",
+        }
+      );
+      return;
+    }
+    this._type = type;
+    this._target = target;
+    this._allUsers = allUsers;
+
+    await this.setupDialog();
+    await this.customiseDialog();
+    await this.setupSaveHandler();
+    this._dialogEditSidebar.addEventListener("sidebar-settings-save", async () => {
+        this.saveSettings();
+    });
+  }
+}
+

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -1,10 +1,12 @@
-import { await_element, waitRepeat, runOnce, selectTree } from "../helpers";
+import { await_element, waitRepeat, runOnce, selectTree, hass_base_el } from "../helpers";
 
 export const AutoSettingsMixin = (SuperClass) => {
   class AutoSettingsMixinClass extends SuperClass {
     _faviconTemplateSubscription;
     _titleTemplateSubscription;
     _sidebarTitleSubscription;
+    // flag to remove legacy Sidebar Settings that hass leaves after migration to user profile
+    _removeLegacySidebarSettings: Boolean = false;
     __currentTitle = undefined;
 
     @runOnce()
@@ -35,6 +37,7 @@ export const AutoSettingsMixin = (SuperClass) => {
       window.addEventListener("location-changed", runUpdates);
 
       this.addEventListener("browser-mod-config-update", this._runDefaultAction, {once: true});
+      this._watchEditSidebar();
     }
 
     async _auto_settings_setup() {
@@ -45,12 +48,16 @@ export const AutoSettingsMixin = (SuperClass) => {
       // Sidebar panel order and hiding
       if (settings.sidebarPanelOrder) {
         localStorage.setItem("sidebarPanelOrder", settings.sidebarPanelOrder);
+      } else if (this._removeLegacySidebarSettings) {
+        localStorage.removeItem("sidebarPanelOrder");
       }
       if (settings.sidebarHiddenPanels) {
         localStorage.setItem(
           "sidebarHiddenPanels",
           settings.sidebarHiddenPanels
         );
+      } else if (this._removeLegacySidebarSettings){
+        localStorage.removeItem("sidebarHiddenPanels");
       }
 
       // Default panel
@@ -219,6 +226,51 @@ export const AutoSettingsMixin = (SuperClass) => {
             data: data,
           });
         })
+      }
+    }
+
+    async _watchEditSidebar() {
+      let sidebar = undefined;
+      let cnt = 0;
+      while (!sidebar && cnt++ < 10) {
+        sidebar = await selectTree(
+          document.body,
+          "home-assistant $ home-assistant-main $ ha-drawer ha-sidebar"
+        );
+        if (!sidebar) await new Promise((r) => setTimeout(r, 1000));
+      }
+      // Home Assistant 2025.6 removed editMode from sidebar
+      // so this is the best check to see if sidebar settings dialog is available
+      if (sidebar && sidebar.editMode === undefined) {
+        // both Sidebar and Profile edit can fire show-dialog for dialog-edit-sidebar
+        // so listen on hass main
+        const main = await selectTree(
+          document.body,
+          "home-assistant $ home-assistant-main"
+        )
+        if (main) {
+          main.addEventListener("show-dialog", (ev: any) => {
+            if (ev.detail?.dialogTag === "dialog-edit-sidebar") {
+              if (ev.detail?.browser_mod_continue) return;
+              const evShowDialog = new CustomEvent("show-dialog", { bubbles: true, composed: true, detail: { browser_mod_continue: true, ...ev.detail } })
+              ev.stopPropagation();
+              window.browser_mod?.showPopup(
+                'Edit sidebar',
+                'Browser Mod is installed. It is recommend that you use Browser Mod Frontend Settings to manage sidebar settings.',
+                {
+                  right_button: "Continue",
+                  right_button_action: () => { main.dispatchEvent(evShowDialog) },
+                  left_button: "Edit with Browser Mod",
+                  left_button_action: () => { this.browser_navigate('/browser-mod') },
+                  style: 'ha-dialog { position: fixed; z-index: 999; }' // Need to be above open drawer sidebar
+                }
+              )
+            }
+          });
+        }
+        // flag to remove legacy sidebar settings which hass may have left over
+        this._removeLegacySidebarSettings = true;
+        this._auto_settings_setup();
       }
     }
 


### PR DESCRIPTION
Closes #872 

Three parts:

1. Show message if user proceeds to customise sidebar using Hass method.
2. Method to set sidebar settings to use new dialog (note: doing nothing is not an option as the edit mode has been removed.
3. Show message if current user has synced settings in Home Assistant user profile and allow clearning. NOTE: There is only an API to managed frontend hass data for current user, so note includes information to login as other users to check as needed.