### PR TITLE
Frontend overlay icon

### DIFF
--- a/custom_components/browser_mod/store.py
+++ b/custom_components/browser_mod/store.py
@@ -25,6 +25,7 @@ class SettingsStoreData:
     autoRegister = attr.ib(type=bool, default=None)
     lockRegister = attr.ib(type=bool, default=None)
     saveScreenState = attr.ib(type=bool, default=None)
+    overlayIcon = attr.ib(type=object, default=None)
 
     @classmethod
     def from_dict(cls, data):

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -91,6 +91,30 @@ This will hide the header bar. Completely. It does not care if there are useful 
 
 > Tip: See the big yellow warning box at the top of this card? For some reason, it seems to be really easy to forget you turned this on. Please do not bother the Home Assistant team about the header bar missing if you have hidden it yourself. Really, I've forgotten multiple times myself.
 
+### Overlay icon
+
+Allow for an overlay icon to apear on certain Dashboards/Panels and carry out an action when clicked. Even with good Dashboard design, you can end up on a Home Assistant panel that assumes header and sidebar navigation. E.g. History Panel, Energy Dashboard. An overlay icon allows for a method to show an icon and carry out an action.
+
+> Example: Your icon could be `mdi:chevron-left`, titled _Back_ with the following action using `browser_mod.javascript`.
+>
+>```yaml
+>action: browser_mod.javascript
+>data:
+>  code: history.back()
+>```
+>
+> Alternatively, use `mdi:home`, titled _Home_ with the following action using `browser_mod.navigate`
+>
+>```yaml
+>action: browser_mod.navigate
+>data:
+>  path: /lovelace
+>```
+
+See [Default action](#default-action) below for tips on calling multiple actions.
+
+__IMPORTANT__: Like actions popups and notifications, this setting DOES NOT support templates.
+
 ### Default dashboard
 
 Set the default dashboard that is shown when you access `https://<your home assistant url>/` with nothing after the `/`.

--- a/js/config_panel/frontend-settings-card.ts
+++ b/js/config_panel/frontend-settings-card.ts
@@ -11,6 +11,7 @@ class BrowserModFrontendSettingsCard extends LitElement {
   @property() hass;
 
   @state() _dashboards = [];
+  @state() _panels = {};
 
   @state() _editSidebar = false;
   @state() _hassUserHasSidebarSettings = false;
@@ -33,6 +34,7 @@ class BrowserModFrontendSettingsCard extends LitElement {
         this._dashboards = await this.hass.callWS({
           type: "lovelace/dashboards/list",
         });
+        this._panels = this.hass.panels;
         this.checkHassUserSidebarSettings();
      })();
     }
@@ -121,6 +123,14 @@ class BrowserModFrontendSettingsCard extends LitElement {
         custom_value: true,
       },
     };
+    const pl = Object.values(this._panels)
+      .filter((p: { url_path: string, title: string }) => {
+        if (!p.title) return false;
+        return true;
+      }).map((p: { url_path: string, title: string }) => {
+        return { value: p.url_path, label: this.hass.localize?.(`panel.${p.title}`) || p.title };
+      });
+    const panels = [{ value: "lovelace", label: this.hass.localize?.("panel.states") || "lovelace (default)" }, ...pl]
     return html`
       <ha-card header="Frontend Settings" outlined>
         <div class="card-content">
@@ -216,6 +226,76 @@ class BrowserModFrontendSettingsCard extends LitElement {
               .hass=${this.hass}
               .settingKey=${"hideHeader"}
               .settingSelector=${{ boolean: {}, label: "Hide header" }}
+            ></browser-mod-settings-table>
+          </ha-expansion-panel>
+
+          <ha-expansion-panel
+            .header=${"Overlay icon"}
+            .secondary=${"An overlay icon with action to show on selected panels."}
+            leftChevron
+          >
+            <browser-mod-settings-table
+              .hass=${this.hass}
+              .settingKey=${"overlayIcon"}
+              .settingSelector=${{ schema:
+                [
+                  {
+                    name: "icon",
+                    label: "Icon",
+                    selector: { icon: {} }
+                  },
+                  {
+                    name: "title",
+                    label: "Title",
+                    selector: { text: {} },
+                  },
+                  {
+                    name: "action",
+                    label: "Action",
+                    selector: { object: {} },
+                  },
+                  {
+                    name: "panels",
+                    label: "Show on panels",
+                    selector: { select: { multiple: true, options: panels,mode: "dropdown" } }
+                  },
+                  {
+                    type: "grid",
+                    schema: [
+                      {
+                        name: "top",
+                        label: "Top",
+                        selector: { number: {} },
+                      },
+                      {
+                        name: "left",
+                        label: "Left",
+                        selector: { number: {} },
+                      },
+                      {
+                        name: "bottom",
+                        label: "Bottom",
+                        selector: { number: {} },
+                      },
+                      {
+                        name: "right",
+                        label: "Right",
+                        selector: { number: {} },
+                      },
+                    ],
+                  },
+                  {
+                    name: "class",
+                    label: "Class",
+                    selector: { text: {} }
+                  },
+                  {
+                    name: "style",
+                    label: "CSS style",
+                    selector: { text: { multiline: true } },
+                  },
+                ]
+              }}
             ></browser-mod-settings-table>
           </ha-expansion-panel>
 

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -1,4 +1,5 @@
-import { await_element, waitRepeat, runOnce, selectTree, hass_base_el } from "../helpers";
+import { await_element, waitRepeat, runOnce, selectTree } from "../helpers";
+import { OverlayIcon } from "./overlay-icon"
 
 export const AutoSettingsMixin = (SuperClass) => {
   class AutoSettingsMixinClass extends SuperClass {
@@ -8,6 +9,7 @@ export const AutoSettingsMixin = (SuperClass) => {
     // flag to remove legacy Sidebar Settings that hass leaves after migration to user profile
     _removeLegacySidebarSettings: Boolean = false;
     __currentTitle = undefined;
+    _overlayIcon: OverlayIcon = undefined;
 
     @runOnce()
     async runHideHeader() {
@@ -20,12 +22,18 @@ export const AutoSettingsMixin = (SuperClass) => {
       await waitRepeat(() => this._updateTitle(), 3, 500);
     }
 
+    @runOnce(true)
+    async updateOverlayIcon() {
+      this._updateOverlayIcon();
+    }
+
     constructor() {
       super();
 
       const runUpdates = async () => {
         this.runUpdateTitle();
         this.runHideHeader();
+        this.updateOverlayIcon();
       };
 
       const searchParams = new URLSearchParams(window.location.search);
@@ -42,6 +50,7 @@ export const AutoSettingsMixin = (SuperClass) => {
       });
 
       window.addEventListener("location-changed", runUpdates);
+      window.addEventListener("popstate", runUpdates);
 
       this.addEventListener("browser-mod-ready", this._runDefaultAction, {once: true});
       this._watchEditSidebar();
@@ -136,6 +145,9 @@ export const AutoSettingsMixin = (SuperClass) => {
             );
         })();
       }
+
+      // OverlayIcon
+      this._setupOverlayIcon();
     }
 
     async _updateSidebarTitle({ result }) {
@@ -233,6 +245,52 @@ export const AutoSettingsMixin = (SuperClass) => {
             data: data,
           });
         })
+      }
+    }
+
+    _runOverlayIconAction(action) {
+      if (action) {
+        var action_action = action;
+        if (!Array.isArray(action_action)) {
+          action_action = [action_action];
+        }
+        action_action.forEach(async (actionItem) => {
+          var { action, service, target, data } = actionItem;
+          service = (action === undefined || action === "call-service") ? service : action;
+          this._service_action({
+            service,
+            target,
+            data: data,
+          });
+        })
+      }    
+    }
+    
+    async _setupOverlayIcon() {
+      if (this.settings.overlayIcon) {
+        if (!this._overlayIcon) {
+          this._overlayIcon = new OverlayIcon(
+                                this.settings.overlayIcon,
+                                this._runOverlayIconAction.bind(this)
+                              )
+          document.body.append(this._overlayIcon);
+          this._updateOverlayIcon();
+        }
+      } else {
+        this._overlayIcon?.remove();
+        this._overlayIcon = undefined;
+      }
+    }
+
+    async _updateOverlayIcon() {
+      if (this.settings.overlayIcon && this._overlayIcon) {
+        const firstPathPart = window.location.pathname?.split('/')?.[1];
+        if (firstPathPart)
+          if (this.settings.overlayIcon.panels?.includes(firstPathPart)) {
+            this._overlayIcon.show = "";
+          } else {
+            this._overlayIcon.show = undefined;
+          }
       }
     }
 

--- a/js/plugin/overlay-icon.ts
+++ b/js/plugin/overlay-icon.ts
@@ -1,0 +1,114 @@
+import { LitElement, html, css } from "lit";
+import { property, query, state } from "lit/decorators.js";
+
+export class OverlayIcon extends LitElement {
+  @property({reflect: true}) show: string;
+
+  @state() icon: string;
+  @state() title: string;
+  @state() top: number;
+  @state() left: number;
+  @state() bottom: number;
+  @state() right: number;
+  @state() class: string;
+  @state() userStyle: string;
+
+  private action: object;
+  private _actionCallback: (action: object) => void;
+
+  constructor(
+    settings: object, 
+    actionCallback: (action: object) => void) 
+  {
+    super();
+
+    this.settings = settings;
+    this._actionCallback = actionCallback;
+    this.show = "";
+  }
+
+  set settings(value) {
+    this.icon = value?.icon ?? "";
+    this.title = value?.title ?? "";
+    this.action = value.action;
+    this.top = value.top;
+    this.left = value.left;
+    this.bottom = value.bottom;
+    this.right = value.right;
+    this.class = value.class ?? "";
+    this.userStyle = value.style ?? "";
+  }
+
+  actionCallback(ev: MouseEvent) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    this.blur();
+    this._actionCallback?.(this.action);
+  }
+
+  async connectedCallback() {
+    super.connectedCallback();
+
+    await Promise.all(
+      [
+        customElements.whenDefined("ha-icon-button"),
+        customElements.whenDefined("ha-icon")
+      ]
+    )
+  }
+
+  _renderDynamicStyles() {
+    let styles = ":host {\n";
+    if (this.top !== undefined) styles += `  top: ${this.top}px;\n`;
+    if (this.left !== undefined) styles += `  left: ${this.left}px;\n`;
+    if (this.bottom !== undefined) styles += `  bottom: ${this.bottom}px;\n`;
+    if (this.right !== undefined) styles += `  right: ${this.right}px;\n`;
+    styles += "}\n\n"
+    if (this.userStyle) styles += `\n${this.userStyle}`;
+    return styles;
+  }
+
+  render() {
+    if (!this.show === undefined) 
+      return html``;
+
+    return html`
+      <div class="browser-mod-overlay-icon">
+        <ha-icon-button
+          class=${this.class}
+          .title=${this.title}
+          @click=${this.actionCallback}
+        >
+          <ha-icon
+            icon=${this.icon}
+          ></ha-icon>
+        </ha-icon-button>
+        </ha-icon>
+      </div>
+      <style>
+        ${this._renderDynamicStyles()}
+      </style>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      :host([show]) {
+        display: block;
+        position: fixed;
+        z-index: 9999;
+      }
+      
+      :host {
+        display: none;
+      }
+
+      ha-icon {
+        display: grid;
+      }
+    `;
+  }
+}
+
+if (!customElements.get("browser-mod-overlay-icon"))
+  customElements.define("browser-mod-overlay-icon", OverlayIcon);

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -160,6 +160,16 @@ class BrowserModPopup extends LitElement {
     });
   }
 
+  _setFormdata(schema) {
+    for (const i of schema) {
+        if (i["schema"]) {
+          this._setFormdata(i["schema"]);
+        } else if (i.name && i.default !== undefined) {
+          this._formdata[i.name] = i.default;
+        }
+      }
+   }
+
   async setupDialog(
     title,
     content,
@@ -204,11 +214,7 @@ class BrowserModPopup extends LitElement {
       form.computeLabel = (s) => s.label ?? s.name;
       form.hass = window.browser_mod.hass;
       this._formdata = {};
-      for (const i of content) {
-        if (i.name && i.default !== undefined) {
-          this._formdata[i.name] = i.default;
-        }
-      }
+      this._setFormdata(content);
       form.data = this._formdata;
       provideHass(form);
       form.addEventListener("value-changed", (ev) => {
@@ -344,7 +350,7 @@ class BrowserModPopup extends LitElement {
                         <ha-icon-button
                           slot="actionItems"
                           title=${icon.title ?? ""}
-                          @click=${() => { this.blur(); this._icon_action(index)} }
+                          @click=${() => this._icon_action(index)}
                           class=${icon.class ?? ""}
                         >
                           <ha-icon .icon=${icon.icon}></ha-icon>


### PR DESCRIPTION
Allow for an overlay icon to apear on certain Dashboards/Panels and carry out an action when clicked. Even with good Dashboard design, you can end up on a Home Assistant panel that assumes header and sidebar navigation. E.g. History Panel, Energy Dashboard. An overlay icon allows for a method to show an icon and carry out an action.

Closes #851 