### PR TITLE
Fix header icons not showing in popup card preview in UI

### DIFF
--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -282,6 +282,3 @@ export const debounce = <T extends any[]>(
   };
   return debouncedFunc;
 };
-
-export const mapObject = (arr, fn) =>
-  Object.fromEntries(arr.map((el, i, arr) => [el, fn(el, i, arr)]));

--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -282,3 +282,6 @@ export const debounce = <T extends any[]>(
   };
   return debouncedFunc;
 };
+
+export const mapObject = (arr, fn) =>
+  Object.fromEntries(arr.map((el, i, arr) => [el, fn(el, i, arr)]));

--- a/js/plugin/popup-card.ts
+++ b/js/plugin/popup-card.ts
@@ -2,9 +2,9 @@ import { LitElement, html, css } from "lit";
 import { property, state } from "lit/decorators.js";
 
 import "./popup-card-editor";
-import { getLovelaceRoot, hass_base_el, mapObject } from "../helpers";
+import { getLovelaceRoot, hass_base_el } from "../helpers";
 import { repeat } from "lit/directives/repeat.js";
-import { classMap } from "lit/directives/class-map.js";
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { icon } from "./types";
 
 class PopupCard extends LitElement {
@@ -66,13 +66,7 @@ class PopupCard extends LitElement {
               (icon: icon, index) => html`
               <ha-icon-button
                 .title=${icon.title ?? ""}
-                class=${
-                  classMap(icon.class ? 
-                    mapObject( icon.class.split(" ").filter((x) => x.length > 0),
-                                c => true)
-                    : {}
-                  )
-                }
+                class=${ifDefined(icon.class)}
               >
                 <ha-icon 
                   .icon=${icon.icon ?? ""}
@@ -86,13 +80,7 @@ class PopupCard extends LitElement {
             html`
               <ha-icon-button
                 .title=${this._config.icon_title ?? ""}
-                class=${
-                  classMap(this._config.icon_class ? 
-                    mapObject( this._config.icon_class.split(" ").filter((x) => x.length > 0),
-                                c => true)
-                    : {}
-                  )
-                }
+                class=${ifDefined(this._config.icon_class)}
               >
                 <ha-icon 
                   .icon=${this._config.icon}

--- a/js/plugin/popup-card.ts
+++ b/js/plugin/popup-card.ts
@@ -2,9 +2,9 @@ import { LitElement, html, css } from "lit";
 import { property, state } from "lit/decorators.js";
 
 import "./popup-card-editor";
-import { getLovelaceRoot, hass_base_el } from "../helpers";
+import { getLovelaceRoot, hass_base_el, mapObject } from "../helpers";
 import { repeat } from "lit/directives/repeat.js";
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from "lit/directives/class-map.js";
 import { icon } from "./types";
 
 class PopupCard extends LitElement {
@@ -66,7 +66,13 @@ class PopupCard extends LitElement {
               (icon: icon, index) => html`
               <ha-icon-button
                 .title=${icon.title ?? ""}
-                class=${ifDefined(icon.class)}
+                class=${
+                  classMap(icon.class ? 
+                    mapObject( icon.class.split(" ").filter((x) => x.length > 0),
+                                c => true)
+                    : {}
+                  )
+                }
               >
                 <ha-icon 
                   .icon=${icon.icon ?? ""}
@@ -80,7 +86,13 @@ class PopupCard extends LitElement {
             html`
               <ha-icon-button
                 .title=${this._config.icon_title ?? ""}
-                class=${ifDefined(this._config.icon_class)}
+                class=${
+                  classMap(this._config.icon_class ? 
+                    mapObject( this._config.icon_class.split(" ").filter((x) => x.length > 0),
+                                c => true)
+                    : {}
+                  )
+                }
               >
                 <ha-icon 
                   .icon=${this._config.icon}

--- a/js/plugin/popup-card.ts
+++ b/js/plugin/popup-card.ts
@@ -3,6 +3,9 @@ import { property, state } from "lit/decorators.js";
 
 import "./popup-card-editor";
 import { getLovelaceRoot, hass_base_el } from "../helpers";
+import { repeat } from "lit/directives/repeat.js";
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { icon } from "./types";
 
 class PopupCard extends LitElement {
   @property() hass;
@@ -48,7 +51,7 @@ class PopupCard extends LitElement {
     this.setHidden(!this.preview);
     if (!this.preview) return html``;
     return html` <ha-card>
-      <div class="app-toolbar">
+      <div class="header">
         ${this._config.dismissable
           ? html`
               <ha-icon-button>
@@ -57,8 +60,39 @@ class PopupCard extends LitElement {
             `
           : ""}
         <div class="main-title">${this._config.title}</div>
+        ${this._config.icons
+          ? repeat(
+              this._config.icons,
+              (icon: icon, index) => html`
+              <ha-icon-button
+                .title=${icon.title ?? ""}
+                class=${ifDefined(icon.class)}
+              >
+                <ha-icon 
+                  .icon=${icon.icon ?? ""}
+                >
+                </ha-icon>
+              </ha-icon-button>
+            `
+            )
+          : 
+          this._config.icon ?
+            html`
+              <ha-icon-button
+                .title=${this._config.icon_title ?? ""}
+                class=${ifDefined(this._config.icon_class)}
+              >
+                <ha-icon 
+                  .icon=${this._config.icon}
+                >
+                </ha-icon>
+              </ha-icon-button>
+            ` : "" 
+          }
       </div>
-      ${this._element}
+      <div class="content">
+        ${this._element}
+      </div>
       <style>
         :host {
         ${this._config.style}
@@ -112,26 +146,28 @@ class PopupCard extends LitElement {
           var(--ha-card-background, var(--card-background-color, white))
         );
       }
-      .app-toolbar {
+      .header {
         color: var(--primary-text-color);
         background-color: var(
           --popup-header-background-color,
           var(--popup-background-color, --sidebar-background-color)
         );
-        display: var(--layout-horizontal_-_display);
-        flex-direction: var(--layout-horizontal_-_flex-direction);
+        display: var(--layout-horizontal_-_display, flex);
+        flex-direction: var(--layout-horizontal_-_flex-direction, row);
         align-items: var(--layout-center_-_align-items);
-        height: 64px;
-        padding: 0 16px;
+        padding: 12px;
         font-size: var(--app-toolbar-font-size, 20px);
       }
       ha-icon-button > * {
         display: flex;
       }
       .main-title {
-        margin-left: 16px;
-        line-height: 1.3em;
-        max-height: 2.6em;
+        flex: 1;
+        font-size: var(--ha-font-size-xl);
+        line-height: var(--ha-line-height-condensed);
+        font-weight: var(--ha-font-weight-normal);
+        padding: 10px 4px;
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
       }
@@ -140,10 +176,13 @@ class PopupCard extends LitElement {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        min-height: 52px;
         margin: 0px;
-        padding: 8px;
-        border-top: 1px solid transparent;
+        padding: 8px 16px 8px 24px;
+        border-top: 1px solid var(--divider-color);
+      }
+
+      .content {
+        padding: 8px 8px 20px 8px;
       }
     `;
   }

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -2,14 +2,15 @@ import { LitElement, html, css } from "lit";
 import { property, query } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { repeat } from "lit/directives/repeat.js";
-import {ifDefined} from 'lit/directives/if-defined.js';
+import {classMap} from 'lit/directives/class-map.js';
 import {
   provideHass,
   loadLoadCardHelpers,
   hass_base_el,
   selectTree,
   getMoreInfoDialog,
-  getMoreInfoDialogHADialog
+  getMoreInfoDialogHADialog,
+  mapObject,
 } from "../helpers";
 import { loadHaForm } from "../helpers";
 import { ObjectSelectorMonitor } from "../object-selector-monitor";
@@ -346,7 +347,13 @@ class BrowserModPopup extends LitElement {
                           slot="actionItems"
                           title=${icon.title ?? ""}
                           @click=${() => { this.blur(); this._icon_action(index)} }
-                          class=${ifDefined(icon.class)}
+                          class=${
+                            classMap(icon.class ? 
+                              mapObject( icon.class.split(" ").filter((x) => x.length > 0),
+                                         c => true)
+                              : {}
+                            )
+                          }
                         >
                           <ha-icon .icon=${icon.icon}></ha-icon>
                         </ha-icon-button>

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -2,15 +2,14 @@ import { LitElement, html, css } from "lit";
 import { property, query } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { repeat } from "lit/directives/repeat.js";
-import {classMap} from 'lit/directives/class-map.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   provideHass,
   loadLoadCardHelpers,
   hass_base_el,
   selectTree,
   getMoreInfoDialog,
-  getMoreInfoDialogHADialog,
-  mapObject,
+  getMoreInfoDialogHADialog
 } from "../helpers";
 import { loadHaForm } from "../helpers";
 import { ObjectSelectorMonitor } from "../object-selector-monitor";
@@ -347,13 +346,7 @@ class BrowserModPopup extends LitElement {
                           slot="actionItems"
                           title=${icon.title ?? ""}
                           @click=${() => { this.blur(); this._icon_action(index)} }
-                          class=${
-                            classMap(icon.class ? 
-                              mapObject( icon.class.split(" ").filter((x) => x.length > 0),
-                                         c => true)
-                              : {}
-                            )
-                          }
+                          class=${ifDefined(icon.class)}
                         >
                           <ha-icon .icon=${icon.icon}></ha-icon>
                         </ha-icon-button>

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css } from "lit";
 import { property, query } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { repeat } from "lit/directives/repeat.js";
+import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   provideHass,
   loadLoadCardHelpers,
@@ -345,7 +346,7 @@ class BrowserModPopup extends LitElement {
                           slot="actionItems"
                           title=${icon.title ?? ""}
                           @click=${() => { this.blur(); this._icon_action(index)} }
-                          class=${icon.class ?? ""}
+                          class=${ifDefined(icon.class)}
                         >
                           <ha-icon .icon=${icon.icon}></ha-icon>
                         </ha-icon-button>


### PR DESCRIPTION
Also tweaked styles of preview to match better those of popup. Styles needed to be adjusted anyhow to allow for header to be flex row. As it was, the title was not on the same line as the close icon.

Fixes #897 