### PR TITLE
Fix memory leak in certain circumstances.

### DIFF
--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -122,11 +122,15 @@ export async function getMoreInfoDialogHADialog(wait = false) {
 }
 
 export async function hass_base_el() {
-  await Promise.race([
-    customElements.whenDefined("home-assistant"),
-    customElements.whenDefined("hc-main"),
-  ]);
-
+  const customElement = customElements.get("home-assistant") ??
+    customElements.get("hc-main");
+  if (customElement === undefined) {
+    await Promise.race([
+      customElements.whenDefined("home-assistant"),
+      customElements.whenDefined("hc-main"),
+    ]);
+  }
+  
   const element = customElements.get("home-assistant")
     ? "home-assistant"
     : "hc-main";

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -573,7 +573,7 @@ export const PopupMixin = (SuperClass) => {
 
       this._popupEl.addEventListener("browser-mod-style-hass-more-info-dialog", async (ev: CustomEvent) => {
         if (!this._popupEl?._allowNestedMoreInfo) return;
-        const hassMoreInfoDialog = await getMoreInfoDialog(true);
+        const hassMoreInfoDialog = await getMoreInfoDialog(ev.detail?.apply);
         if (hassMoreInfoDialog) {
           let styleEl = hassMoreInfoDialog.shadowRoot.querySelector("#browser-mod-style");
           if (!styleEl) {


### PR DESCRIPTION
Fixes #905 

Primary fix is to not wait for more-info dialog when resetting style, as if we styled it it would be available. i.e. only need to wait when styling.

Secondary fix is to only use promise.race when needed as promise.race and promise.all have inherent memory leak when used on long enduring promises. See [HERE](https://levelup.gitconnected.com/unfixable-memory-leaks-in-promise-race-28e5c5a6032c) for a good write up on the issue.