### PR TITLE
Fix Frontend user settings not always applying

### DIFF
--- a/js/plugin/browser.ts
+++ b/js/plugin/browser.ts
@@ -22,6 +22,9 @@ export const BrowserStateMixin = (SuperClass) => {
       this.addEventListener("browser-mod-ready", () =>
         this._browser_state_update()
       );
+      this.addEventListener("browser-mod-user-ready", () =>
+        this._browser_state_update()
+      );
 
       this.connectionPromise.then(() => this._browser_state_update());
 
@@ -43,7 +46,7 @@ export const BrowserStateMixin = (SuperClass) => {
             path: window.location.pathname,
             visibility: document.visibilityState,
             userAgent: navigator.userAgent,
-            currentUser: this.hass?.user?.name,
+            currentUser: this.user?.name,
             fullyKiosk: this.fully || false,
             width: window.innerWidth,
             height: window.innerHeight,
@@ -52,7 +55,7 @@ export const BrowserStateMixin = (SuperClass) => {
             charging: window.fully?.isPlugged() ?? battery?.charging,
             darkMode: this.hass?.themes?.darkMode,
 
-            userData: this.hass?.user,
+            userData: this.user,
             ip_address: window.fully?.getIp4Address(),
             fully_data: this.fully_data,
           },

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -48,11 +48,16 @@ export const AutoSettingsMixin = (SuperClass) => {
         this._auto_settings_setup();
         runUpdates();
       });
+      
+      this.addEventListener("browser-mod-user-ready", () => {
+        this._auto_settings_setup();
+        runUpdates();
+      });
 
       window.addEventListener("location-changed", runUpdates);
       window.addEventListener("popstate", runUpdates);
 
-      this.addEventListener("browser-mod-ready", this._runDefaultAction, {once: true});
+      this.addEventListener("browser-mod-user-ready", this._runDefaultAction, {once: true});
       this._watchEditSidebar();
     }
 

--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -51,7 +51,7 @@ export const ServicesMixin = (SuperClass) => {
         const d = { ...data };
         const t = { ...target };
         if (d.browser_id === "THIS") d.browser_id = this.browserID;
-        if (d.user_id === "THIS") d.user_id = this.hass?.user.id;
+        if (d.user_id === "THIS" && this.user) d.user_id = this.user.id;
         // CALL HOME ASSISTANT SERVICE
         const [domain, srv] = _service.split(".");
         return this.hass.callService(domain, srv, d, t);


### PR DESCRIPTION
Frontend user subscription may be delayed from Browser Mod Integration ready. This PR fixes this state by adding a `broswer-mod-user-ready` event and also uses a `get` for `user` which matches what different mixins were using for `this.hass?.user...`. While I would have wanted to set the `get` to return an empty object `{}`, I have left returning `this.hass.user` which will be `null`. This means the `userData` attributes of the Browser User sensor will keep as `Unknown` rather than `{}`, which otherwise would be a breaking change.

This has been tested by introdcucing an artificial 5000ms delay in the two places (core and auth) where Frontend subscribes to user data. This assisted in seeing that Browser status should be sent also on `broswer-mod-user-ready`.