### PR TITLE
Fix Browser made unavailable when connections still exist

### DIFF
--- a/custom_components/browser_mod/browser.py
+++ b/custom_components/browser_mod/browser.py
@@ -183,7 +183,8 @@ class BrowserModBrowser:
         self._connections = list(
             filter(lambda v: v[0] != connection, self._connections)
         )
-        self.update(hass, {"connected": False})
+        if not self._connections:
+            self.update(hass, {"connected": False})
 
 
 def getBrowser(hass, browserID, *, create=True):


### PR DESCRIPTION
Fixes #913 

Can be reproduced on Android simulated device and may be applicable to other devices.