### PR TITLE
Update hide sidbar routine to be more inline with Home Assistant architecture

### DIFF
--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -81,7 +81,9 @@ Note that this _only_ applies to the current favicon of the page, not any manife
 
 ### Hide Sidebar
 
-This will hide the sidebar wit the navigation links. You can still access all the pages via normal links.
+This will hide the sidebar with the navigation links. You can still access all the pages via normal links.
+
+__IMPORTANT__: When this setting is cleared, the Browser will revert to a state in which the User Setting 'Always hide the sidebar' is in effect, with the sidebar menu icon showing. The 'Always hide the sidebar' setting can be reset in User Settings.
 
 > Tip: add `/browser-mod` to the end of your home assistant URL when you need to turn this off again...
 

--- a/js/config_panel/frontend-settings-card.ts
+++ b/js/config_panel/frontend-settings-card.ts
@@ -207,7 +207,7 @@ class BrowserModFrontendSettingsCard extends LitElement {
 
           <ha-expansion-panel
             .header=${"Hide sidebar"}
-            .secondary=${"Completely remove the sidebar from all panels"}
+            .secondary=${"Hide sidebar and remove sidebar menu icon from all panels."}
             leftChevron
           >
             <browser-mod-settings-table

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -88,14 +88,22 @@ export const AutoSettingsMixin = (SuperClass) => {
 
       // Hide sidebar
       if (settings.hideSidebar === true) {
+        // Set sidebar to always hidden
+        // _hideHeader routine will remove sidebar the menu button
         selectTree(
           document.body,
-          "home-assistant $ home-assistant-main"
-        ).then((el) => el?.style?.setProperty("--mdc-drawer-width", "0px"));
-        selectTree(
-          document.body,
-          "home-assistant $ home-assistant-main $ ha-drawer ha-sidebar"
-        ).then((el) => el?.remove?.());
+          "home-assistant"
+        ).then((el) => {
+          el.updateComplete.then(() => {
+            el.dispatchEvent(
+              new CustomEvent("hass-dock-sidebar", {
+                detail: {
+                  dock: "always_hidden",
+                }
+              })
+            )
+          })
+        });
       }
 
       // Sidebar title


### PR DESCRIPTION
This is to work around issue users are still reporting in that the ha-drawer width CSS (--mdc-drawer-width) is not being applied. Though I can't replicate, it must be to do with a strange CSS property inheritance issue in that setting on an element  is not overridng the shadow DOM styles for ha-drawer([expanded]) etc - possibly timing in when the Lit static styles are applied. So the best way I believe to address this is to use the method by which Home Assistant sets the sidebar to always hidden with the `"hass-dock-sidebar"` event with `dock: "always_hidden"`. This together with removing the sidebar menu icon provides the same outcome with less risk of failing like it does now. Also, it would allow for admin users to use browser_mod.javascript to be able have a button to fire the same event to show a docked sidebar (`"hass-dock-sidebar"` event with `dock: "docked"`).

The one caveat with this method is that clearing the Browser Mod setting leaves it in "always_hidden". GIven that admins are wanting to set this and leave, I don't see that this is an issue, and I have updated documentation to point it out.