### PR TITLE
Fix BrowserID edit field display on small size screens

### DIFF
--- a/js/config_panel/browser-settings-card.ts
+++ b/js/config_panel/browser-settings-card.ts
@@ -4,6 +4,7 @@ import { property, state } from "lit/decorators.js";
 class BrowserModRegisteredBrowsersCard extends LitElement {
   @property() hass;
   @property() dirty = false;
+  @property({ type: Boolean }) public narrow = false;
 
   toggleRegister() {
     if (!window.browser_mod?.ready) return;
@@ -71,7 +72,7 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
             ></ha-switch>
           </ha-settings-row>
 
-          <ha-settings-row>
+          <ha-settings-row .narrow=${this.narrow}>
             <span slot="heading">Browser ID</span>
             <span slot="description"
               >A unique identifier for this browser-device combination.</span
@@ -257,7 +258,6 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
         justify-content: space-between;
       }
       ha-textfield {
-        width: 250px;
         display: block;
         margin-top: 8px;
       }

--- a/js/config_panel/main.ts
+++ b/js/config_panel/main.ts
@@ -45,6 +45,7 @@ loadConfigDashboard().then(() => {
           <ha-config-section .narrow=${this.narrow} full-width>
             <browser-mod-browser-settings-card
               .hass=${this.hass}
+              .narrow=${this.narrow}
             ></browser-mod-browser-settings-card>
 
             ${this.hass.user?.is_admin


### PR DESCRIPTION
In 2025.7. Home Assistant Frontend instroduced `min-width: 0` on text fields. This change updates the BrowserID field to cope with the Frontend change.

https://github.com/user-attachments/assets/3c97109c-71ad-4abf-b86e-9a1006a03063

