### PR TITLE
Don't require audio interaction when media player disabled.

### DIFF
--- a/custom_components/browser_mod/browser.py
+++ b/custom_components/browser_mod/browser.py
@@ -134,7 +134,7 @@ class BrowserModBrowser:
 
         hass.create_task(
             self.send(
-                None, browserEntities={k: v.entity_id for k, v in self.entities.items()}
+                None, browserEntities={k: {"entity_id": v.entity_id, "enabled": v.enabled} for k, v in self.entities.items()}
             )
         )
 

--- a/js/plugin/browser-player.ts
+++ b/js/plugin/browser-player.ts
@@ -69,7 +69,7 @@ class BrowserPlayer extends LitElement {
         composed: true,
         cancelable: false,
         detail: {
-          entityId: window.browser_mod.browserEntities?.player,
+          entityId: window.browser_mod.browserEntities?.player?.entity_id,
         },
       })
     );
@@ -109,6 +109,17 @@ class BrowserPlayer extends LitElement {
       return html`
         <ha-card>
           <ha-alert> This browser is not registered to Browser Mod. </ha-alert>
+        </ha-card>
+      `;
+    }
+    if (!window.browser_mod?.browserEntities) {
+      window.setTimeout(() => this.requestUpdate(), 100);
+      return html``;
+    }
+    if (!window.browser_mod?.playerEnabled) {
+      return html`
+        <ha-card>
+          <ha-alert> Media player disabled for this browser. </ha-alert>
         </ha-card>
       `;
     }

--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -102,6 +102,7 @@ export const ConnectionMixin = (SuperClass) => {
         this.fireBrowserEvent(`command-${msg.command}`, msg);
       } else if (msg.browserEntities) {
         this.browserEntities = msg.browserEntities;
+        this.fireBrowserEvent("browser-mod-entities-update");
       } else if (msg.result) {
         this.update_config(msg.result);
       }
@@ -290,6 +291,11 @@ export const ConnectionMixin = (SuperClass) => {
     }
     set cameraEnabled(value) {
       this._reregister({ camera: value });
+    }
+
+    get playerEnabled() {
+      if (!this.registered) return null;
+      return (this.browserEntities as any)?.player?.enabled ?? false;
     }
 
     sendUpdate(data) {

--- a/js/plugin/mediaPlayer.ts
+++ b/js/plugin/mediaPlayer.ts
@@ -12,6 +12,14 @@ export const MediaPlayerMixin = (SuperClass) => {
     constructor() {
       super();
 
+      this.addEventListener("browser-mod-entities-update", () => {
+        this._setup_media_player();
+      }, { once: true });
+    }
+
+    private _setup_media_player() {
+      if (!this.playerEnabled) return;
+
       this._audio_player = new Audio();
       this._audio_player.muted = true;
       this._video_player = document.createElement("video");
@@ -100,11 +108,7 @@ export const MediaPlayerMixin = (SuperClass) => {
         this._player_update();
       });
 
-      this.addEventListener("browser-mod-ready", () =>
-        this._player_update()
-      );
-
-      this.connectionPromise.then(() => this._player_update());
+      this._player_update();
     }
 
     private _show_video_player() {


### PR DESCRIPTION
Fixes #925 

- Allows for Browser to know what entities have been disabled by user. For now, only media player and interaction mixins take advantage of this data change. 
- Any interaction will only be required if media player (server) and camera (local) are enabled.
- Audio interaction will only be required if media player enabled.