### PR TITLE
Allow for custom:popup-card to be targetted by entity area, labels or device

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Yaml configuration:
 
 ```yaml
 type: custom:popup-card
+[entity: <entity_id> ]
 target:
   [entity_id: <entity_id> ]
   [area_id: <area-id>     ]
@@ -115,6 +116,8 @@ card:
 [popup_card_all_views: [true/FALSE]]
 [any parameter from the browser_mod.popup service call except "content"]
 ```
+
+> Note: While using old style `entity` is fully supported, it will not show in the GUI editor if `entity` is not in the current popup-card config. In this case add an entity to `target`.
 
 ## Browser Player
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here's a great overview of the functionality by [Smart Home Scene](https://smart
 
 # Browser Mod Configuration Panel
 
-After installing Browser Mod you should see a new panel called _Browser Mod_ in the sidebar. This is where you controll any Browser Mod settings.
+After installing Browser Mod you should see a new panel called _Browser Mod_ in the sidebar. This is where you control any Browser Mod settings.
 
 ### See [Configuration Panel](documentation/configuration-panel.md) for more info
 \
@@ -91,30 +91,34 @@ Browser Mod has a number of services you can call to cause things to happen in t
 
 ## Popup card
 
-A popup card can be used to replace the more-info dialog of an entity with something of your choosing.
+A popup card can be used to replace the more-info dialog of an entity with something of your choosing. The entity can be targetted by entity, area, label or device.
 
-To use it, add a "Custom: Popup card" to a dashboard view via the GUI, pick the entity you want to override, configure the card and set up the popup like for the [`browser_mod.popup` service](documentation/services.md).
+To use it, add a "Custom: Popup card" to a dashboard view via the GUI, pick the target (entity, area, label, device) you want to override, configure the card and set up the popup like for the [`browser_mod.popup` service](documentation/services.md).
 
 The card will be visible only while you're in Edit mode.
 
 Custom popup cards are either local to the current Dashboard view (default) or can be used across all views of the Dashboard. Use the `Popup card is available for use in all views` GUI switch or `popup_card_all_views` optional parameter in Yaml. Using global view custom popup cards allows you to use a sub view to store your custom popup cards for a Dashboard, if that fits your use case.
 
+Using a wide target (label, area, device) and/or popup cards which are global to a view, allows for much customisation of more-info dialog to suit most cases.
+
 Yaml configuration:
 
 ```yaml
 type: custom:popup-card
-entity: <entity id>
+target:
+  [entity_id: <entity_id> ]
+  [area_id: <area-id>     ]
+  [label_id: <label-id>   ]
+  [device_id: <device-d>  ]
 card:
   type: ...etc...
 [popup_card_all_views: [true/FALSE]]
 [any parameter from the browser_mod.popup service call except "content"]
 ```
 
-> *Note:* It's advisable to use a `fire-dom-event` tap action instead as far as possible. Popup card is for the few cases where that's not possible. See [`services`](documentation/services.md) for more info.
-
 ## Browser Player
 
-Browser player is a card that allows you to controll the volume and playback on the current Browsers media player.
+Browser player is a card that allows you to control the volume and playback on the current Browsers media player.
 
 Add it to a dashboard via the GUI or through yaml:
 

--- a/custom_components/browser_mod/services.yaml
+++ b/custom_components/browser_mod/services.yaml
@@ -182,9 +182,13 @@ more_info:
     entity:
       name: Entity ID
       description: ""
-      required: true
       selector:
         text:
+    target:
+      name: Target
+      description: ""
+      selector:
+        target:
     large:
       name: Large size
       description: ""

--- a/documentation/services.md
+++ b/documentation/services.md
@@ -141,7 +141,12 @@ Show a more-info dialog.
 ```yaml
 service: browser_mod.more_info
 data:
-  entity: <string>
+  [entity: <string>]
+  [target:]
+    [entity_id: <entity_id> ]
+    [area_id: <area-id>     ]
+    [label_id: <label-id>   ]
+    [device_id: <device-d>  ] 
   [large: <true/FALSE>]
   [ignore_popup_card: <true/FALSE>]
   [browser_id: <Browser IDs>]
@@ -151,8 +156,13 @@ data:
 | | |
 |---|---|
 |`entity`| The entity whose more-info dialog to display. |
+|`target`| If targetting a popup-card, the relevant target which matches the popup-card. |
 |`large`| If true, the dialog will be displayed wider, as if you had clicked the title of the dialog. |
-| `ignore_popup_card` | If true the more-info dialog will be shown even if there's currently a popup-card which would override it. |
+|`ignore_popup_card` | If true the more-info dialog will be shown even if there's currently a popup-card which would override it. |
+
+Note that either `entity` or `target` is required. `target` will only have an effect if a popup-card exists in the view/dashboard(*) which matches `target` by either `entity_id`, `area_id`, `label_id` or `device_id`.
+
+_* Dashboard when popup-card config has `popup_card_all_views: true`._
 
 ## `browser_mod.popup`
 

--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -288,3 +288,25 @@ export const debounce = <T extends any[]>(
   };
   return debouncedFunc;
 };
+
+type NonNullUndefined<T> = T extends undefined
+  ? never
+  : T extends null
+    ? never
+    : T;
+
+/**
+ * Ensure that the input is an array or wrap it in an array
+ * @param value - The value to ensure is an array
+ */
+export function ensureArray(value: undefined): undefined;
+export function ensureArray(value: null): null;
+export function ensureArray<T>(
+  value: T | T[] | readonly T[]
+): NonNullUndefined<T>[];
+export function ensureArray(value) {
+  if (value === undefined || value === null || Array.isArray(value)) {
+    return value;
+  }
+  return [value];
+}

--- a/js/plugin/popup-card-editor.ts
+++ b/js/plugin/popup-card-editor.ts
@@ -4,10 +4,15 @@ import { hass_base_el, loadHaForm, selectTree } from "../helpers";
 import { ObjectSelectorMonitor } from "../object-selector-monitor";
 
 const configSchema = [
-  {
+    {
     name: "entity",
-    label: "Entity",
+    label: "Entity (old style)",
     selector: { entity: {} },
+  },
+  {
+    name: "target",
+    label: "Target",
+    selector: { target: {} },
   },
   {
     name: "title",
@@ -172,6 +177,8 @@ class PopupCardEditor extends LitElement {
   @query("hui-card-element-editor") private _cardEditorEl?;
 
   private _objectSelectorMonitor: ObjectSelectorMonitor;
+  private _schema: Object[];
+  private _schemaOldStyle: Object[];
 
   get settingsValid() {
     return this._settingsValid
@@ -193,6 +200,8 @@ class PopupCardEditor extends LitElement {
       (value: boolean) => { this._settingsValid = value },
       (value: boolean) => { this._showErrors = value }
     );
+    this._schemaOldStyle = configSchema;
+    this._schema = configSchema.slice(1)
   }
 
   firstUpdated(changedProperties: PropertyValues) {
@@ -329,7 +338,7 @@ class PopupCardEditor extends LitElement {
       <ha-form
         .hass=${this.hass}
         .data=${this._config}
-        .schema=${configSchema}
+        .schema=${this._config.entity ? this._schemaOldStyle : this._schema}
         .computeLabel=${(s) => s.label ?? s.name}
         @value-changed=${this._configChanged}
       ></ha-form>

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -603,6 +603,7 @@ export const PopupMixin = (SuperClass) => {
               ev.stopPropagation();
               this.showMoreInfo(
                 actionConfig.entity ? actionConfig.entity : ev.detail.config.entity,
+                {},
                 actionConfig.large ?? false,
                 actionConfig.ignore_popup_card ?? false,
               );
@@ -690,14 +691,14 @@ export const PopupMixin = (SuperClass) => {
       }
     }
 
-    async showMoreInfo(entityId, large = false, ignore_popup_card = undefined) {
+    async showMoreInfo(entityId, target = {}, large = false, ignore_popup_card = undefined) {
       const base = await hass_base_el();
       base.dispatchEvent(
         new CustomEvent("hass-more-info", {
           bubbles: true,
           composed: true,
           cancelable: false,
-          detail: { entityId, ignore_popup_card },
+          detail: { entityId, target, ignore_popup_card },
         })
       );
       if (large) {

--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -70,8 +70,8 @@ export const ServicesMixin = (SuperClass) => {
           break;
 
         case "more_info":
-          const { entity, large, ignore_popup_card } = data;
-          this.showMoreInfo(entity, large, ignore_popup_card);
+          const { entity, target, large, ignore_popup_card } = data;
+          this.showMoreInfo(entity, target, large, ignore_popup_card);
           break;
 
         case "popup":


### PR DESCRIPTION
Implements and closes #908 

So as to be less confusing to new users, `entity` as a config paramater for custom:popup-card will only show if the current card config has `entity:`. New style is to add an `entity` to `target`. `entity:` remains fully supported so this is not a breaking change.

`browser_mod.more_info` allows for `target` as an extension which gets passed to `more-info` event. The default `entityId` remains fully supported.