### PR TITLE
Browser entity variables

### DIFF
--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -178,7 +178,7 @@ Set the order and hidden items of the sidebar. To change this setting:
 ### Sidebar title
 
 This changes the "Home Assistant" text that is displayed at the top of the sidebar.
-Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/).
+Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). Variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
 
 ### Hide interaction icon
 
@@ -187,3 +187,37 @@ This hides the icon in the bottom right corner which indicates that you need to 
 ### Save screen state
 
 This saves the screen state on browser disconnect and restores on browser reconnect. The screen state (on/off) and brightness are both saved. The state will be saved and restored for all browsers that have this setting applied, including those running Fully Kiosk.
+
+---
+
+#### Browser Entities variable
+
+The variable `browser_entities` is available in templates. It is a dictionary of the entities for the Browser and includes the following.
+
+| Variable | Sensor | Example |
+|---|---|---|
+| `browser_entities.path` | Browser path Sensor | _sensor.browser_id_browser_path_ |
+| `browser_entities.visibility` | Browser visibility Sensor | _sensor.browser_id_browser_visibility_ |
+| `browser_entities.userAgent` | Browser userAgent Sensor | _sensor.browser_id_browser_useragent_ |
+| `browser_entities.currentUser` | Browser user Sensor | _sensor.browser_id_browser_user_ |
+| `browser_entities.fullyKiosk` | Browser FullyKiosk Sensor | _binary_sensor.browser_id_browser_fullykiosk_ |
+| `browser_entities.width` | Browser width Sensor | _sensor.browser_id_browser_width_ |
+| `browser_entities.height` | Browser height Sensor | _sensor.browser_id_browser_height_ |
+| `browser_entities.darkMode` | Browser dark mode Sensor | _sensor.browser_id_browser_dark_mode_ |
+| `browser_entities.activity` | Browser activity Sensor | _sensor.browser_id_browser_ |
+| `browser_entities.screen` | Browser screen Sensor | _light.browser_id_browser_screen_ |
+| `browser_entities.player` | Browser player Sensor | _media_player.browser_id_ |
+| `browser_entities.battery_level` | Browser battery Sensor | _sensor.browser_id_browser_battery_ |
+| `browser_entities.charging` | Browser charging Sensor | _binary_sensor.browser_id_browser_charging_ |
+
+Your template can use the `browser_entities` variable to query a sensor state or get attributes of the sensor.
+
+Example: Get the current user name
+```yaml
+{{ states(browser_entities.currentUser) }}
+```
+
+Example: Get the first part of the Browser path
+```yaml
+{{ state_attr(browser_entities.path, 'pathSegments')[1] }}
+```

--- a/documentation/services.md
+++ b/documentation/services.md
@@ -41,7 +41,7 @@ The notable difference between the two is when no target (`browser_id` or `user_
 
 ---
 
-Finally, in *browser* calls there is `browser_id` and `user_id` replacements of `THIS` available. A parameter `browser_id` with the value `THIS` will be replaced with the current Browsers browser ID. A parameter `user_id` with the value of `THIS` will be replaced by the logged in user ID.
+Finally, in *browser* calls there is `browser_id`, `user_id` and `browser_entities` replacements of `THIS` available. A parameter `browser_id` with the value `THIS` will be replaced with the current Browser's browser ID. A parameter `user_id` with the value of `THIS` will be replaced by the logged in user ID. A parameter `browser_entities` with a value of `THIS` will be replaced with a [`browser_entities`](./configuration-panel.md#browser-entities-variable) dictionary.
 
 Ex:
 
@@ -65,7 +65,7 @@ script:
           message: "Button was clicked in {{browser_id}}"
 ```
 
-Will print `"Button was clicked in 79be65e8-f06c78f" to the Home Assistant log.
+Will print `"Button was clicked in 79be65e8-f06c78f"` to the Home Assistant log.
 
 # Calling services
 

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -54,10 +54,15 @@ export const AutoSettingsMixin = (SuperClass) => {
         runUpdates();
       });
 
+      this.addEventListener("browser-mod-entities-update", () => {
+        this._auto_settings_setup();
+        runUpdates();
+      });
+
       window.addEventListener("location-changed", runUpdates);
       window.addEventListener("popstate", runUpdates);
 
-      this.addEventListener("browser-mod-user-ready", this._runDefaultAction, {once: true});
+      this.addEventListener("browser-mod-entities-update", this._runDefaultAction, {once: true});
       this._watchEditSidebar();
     }
 
@@ -117,7 +122,7 @@ export const AutoSettingsMixin = (SuperClass) => {
             await this.connection.subscribeMessage(this._updateSidebarTitle, {
               type: "render_template",
               template: settings.sidebarTitle,
-              variables: {},
+              variables: { browser_id: this.browserID, browser_entities: this.browserEntities },
             });
         })();
       }
@@ -135,7 +140,7 @@ export const AutoSettingsMixin = (SuperClass) => {
             await this.connection.subscribeMessage(this._updateFavicon, {
               type: "render_template",
               template: settings.faviconTemplate,
-              variables: {},
+              variables: { browser_id: this.browserID, browser_entities: this.browserEntities },
             });
         })();
       }
@@ -153,7 +158,7 @@ export const AutoSettingsMixin = (SuperClass) => {
               {
                 type: "render_template",
                 template: settings.titleTemplate,
-                variables: {},
+                variables: { browser_id: this.browserID, browser_entities: this.browserEntities },
               }
             );
         })();

--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -52,6 +52,7 @@ export const ServicesMixin = (SuperClass) => {
         const t = { ...target };
         if (d.browser_id === "THIS") d.browser_id = this.browserID;
         if (d.user_id === "THIS" && this.user) d.user_id = this.user.id;
+        if (d.browser_entities === "THIS") d.browser_entities = this.browserEntities;
         // CALL HOME ASSISTANT SERVICE
         const [domain, srv] = _service.split(".");
         return this.hass.callService(domain, srv, d, t);


### PR DESCRIPTION
Allows for templating and browser call actions to have access to the Browser's entities.

1. Adds `browser_id` and `browser_entities` as variables to Frontend settings templates.
2. Replaces 'browser_entities: THIS` with Browser Entities dictionary.