### PR TITLE
Hide header fix

### DIFF
--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -290,3 +290,21 @@ export const debounce = <T extends any[]>(
 };
 
 export const capitalize = (s: string): string => (s && String(s[0]).toUpperCase() + String(s).slice(1)) || ""
+
+export function compare_deep(a: any, b: any) {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (!(a instanceof Object && b instanceof Object)) return false;
+  for (const x in a) {
+    if (!a.hasOwnProperty(x)) continue;
+    if (!b.hasOwnProperty(x)) return false;
+    if (a[x] === b[x]) continue;
+    if (typeof a[x] !== "object") return false;
+    if (!compare_deep(a[x], b[x])) return false;
+  }
+  for (const x in b) {
+    if (!b.hasOwnProperty(x)) continue;
+    if (!a.hasOwnProperty(x)) return false;
+  }
+  return true;
+}

--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -1,4 +1,4 @@
-import { hass, provideHass } from "../helpers";
+import { compare_deep, hass, provideHass } from "../helpers";
 
 export const ConnectionMixin = (SuperClass) => {
   class BrowserModConnection extends SuperClass {
@@ -114,8 +114,11 @@ export const ConnectionMixin = (SuperClass) => {
         this.LOG("Command:", msg);
         this.fireBrowserEvent(`command-${msg.command}`, msg);
       } else if (msg.browserEntities) {
+        let oldEntities = this.browserEntities;
         this.browserEntities = msg.browserEntities;
-        this.fireBrowserEvent("browser-mod-entities-update");
+        if (!compare_deep(oldEntities, this.browserEntities)) {
+          this.fireBrowserEvent("browser-mod-entities-update");
+        }
       } else if (msg.result) {
         this.update_config(msg.result);
       }

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -13,8 +13,10 @@ export const AutoSettingsMixin = (SuperClass) => {
 
     @runOnce()
     async runHideHeader() {
-      while (!(await this._hideHeader()))
+      let cnt = 0;
+      while (!await this._hideHeader() && cnt++ < 10) {
         await new Promise((r) => setTimeout(r, 500));
+      }
     }
 
     @runOnce(true)
@@ -249,7 +251,11 @@ export const AutoSettingsMixin = (SuperClass) => {
         rootEl.style.setProperty("--header-height", "0px");
         header.style.setProperty("display", "none");
         return true;
-      } else if (menuButton && this.settings.hideSidebar === true) {
+      } else if (
+          menuButton && 
+          this.settings.hideSidebar === true &&
+          this.settings.hideHeader !== true 
+        ) {
         menuButton.remove?.();
         return true;
       }

--- a/js/plugin/frontend-settings.ts
+++ b/js/plugin/frontend-settings.ts
@@ -14,7 +14,7 @@ export const AutoSettingsMixin = (SuperClass) => {
     @runOnce()
     async runHideHeader() {
       let cnt = 0;
-      while (!await this._hideHeader() && cnt++ < 10) {
+      while (!await this._hideHeader() && cnt++ < 20) {
         await new Promise((r) => setTimeout(r, 500));
       }
     }


### PR DESCRIPTION
Fixes #947. 

When both header and sidebar are set to be hidden, and header is not found on first try, hiding of header is not attempted again leaving half hidden header. 

Detail: `--header-height: 0px` is applied as that is done at panel root, which is available. However without `display: none` being applied to `.header` this only leads to a partial hidden header.