### PR TITLE
Use 'capture: true' for value-changed from object selector

### DIFF
--- a/js/object-selector-monitor.ts
+++ b/js/object-selector-monitor.ts
@@ -101,7 +101,7 @@ export class ObjectSelectorMonitor {
         } else {
           this._debounceShowErrors(); 
         }
-      });
+      }, { capture: true } );
     });
   }
 


### PR DESCRIPTION
Change in Frontend for 2025.8 now stops propgation of the Yaml Editor at the Objector Selector level. Using `capture: true` allows to get message first to monitor the Yaml Editor for errors.