### PR TITLE
Media player sometimes unavailable

### DIFF
--- a/js/plugin/require-interact.ts
+++ b/js/plugin/require-interact.ts
@@ -16,9 +16,13 @@ export const RequireInteractMixin = (SuperClass) => {
       super();
 
       this.addEventListener("browser-mod-user-ready", () => {
-        if (this.playerEnabled || this.cameraEnabled) {
-          this.show_indicator(this.playerEnabled);
-        }
+        this.entitiesReady().then(() => {
+          if (this.playerEnabled || this.cameraEnabled) {
+            this.show_indicator(this.playerEnabled);
+          }
+        }).catch((err) => {
+          console.warn(`Browser Mod: ${err}. Timeout waiting for browser entities to be ready. Player will be unavailable.`);
+        });
       });
     }
 

--- a/js/plugin/require-interact.ts
+++ b/js/plugin/require-interact.ts
@@ -21,7 +21,7 @@ export const RequireInteractMixin = (SuperClass) => {
             this.show_indicator(this.playerEnabled);
           }
         }).catch((err) => {
-          console.warn(`Browser Mod: ${err}. Timeout waiting for browser entities to be ready. Player will be unavailable.`);
+          console.warn(`Browser Mod: Failed to wait for browser entities to be ready. Player will be unavailable. Error: ${err}`);
         });
       });
     }


### PR DESCRIPTION
Browser Entities not always available when user ready giving rise to the media player being unavailable as playerEnabled will be false. Fix is to wait for entitiesReady