### PR TITLE
Fix notification with no action_text causing error (2025.9.0b0) or blank button in earlier versions

### DIFF
--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -133,7 +133,7 @@ export const ServicesMixin = (SuperClass) => {
             var { message, action_text, action_action, duration, dismissable } =
               data;
             let act = undefined;
-            if (action_text) {
+            if (action_text && action_text.trim()) {
               act = {
                 text: action_text,
                 action: (ext_data?) => {


### PR DESCRIPTION
Fixes #1003 