### PR TITLE
Fix console warnings when Browser not registered

### DIFF
--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -54,7 +54,7 @@ As settings here may mean you get yourself locked out of Browser Mod panel in so
 
 ### Title template
 
-This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
+This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/). Vairables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
 
 > Ex:
 >
@@ -64,7 +64,7 @@ This allows you to set and dynamically update the title text of the browser tab/
 
 ### Favicon template
 
-This allows you to set and dynamically update the favicon of the browser tab/window. I.e. the little icon next to the page title. Favicons can be .png or .ico files and should be placed in your `<config>/www` directory. The box here should then contain a jinja [template](https://www.home-assistant.io/docs/configuration/templating/) which resolves to the path of the icon with `<config>/www/` replaced by `/local/` (see [Hosting files](https://www.home-assistant.io/integrations/http/#hosting-files)). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
+This allows you to set and dynamically update the favicon of the browser tab/window. I.e. the little icon next to the page title. Favicons can be .png or .ico files and should be placed in your `<config>/www` directory. The box here should then contain a jinja [template](https://www.home-assistant.io/docs/configuration/templating/) which resolves to the path of the icon with `<config>/www/` replaced by `/local/` (see [Hosting files](https://www.home-assistant.io/integrations/http/#hosting-files)). Vairables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
 
 > Ex:
 >
@@ -191,7 +191,7 @@ Set the order and hidden items of the sidebar. To change this setting:
 ### Sidebar title
 
 This changes the "Home Assistant" text that is displayed at the top of the sidebar.
-Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
+Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). Vairables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
 
 ### Hide interaction icon
 
@@ -222,6 +222,8 @@ Using this method means that the new random Browser ID never has sent informatio
 
 The variable `browser_entities` is available in templates. It is a dictionary of the entities for the Browser and includes the following.
 
+> NOTE: If the Browser is not regsitered, `browser_entities` will be undefined. Your template should use `default()`to handle such a case.
+
 | Variable | Sensor | Example |
 |---|---|---|
 | `browser_entities.path` | Browser path Sensor | _sensor.browser_id_browser_path_ |
@@ -243,12 +245,12 @@ Your template can use the `browser_entities` variable to query a sensor state or
 
 Example: Get the current user name
 ```yaml
-{{ states(browser_entities.currentUser) }}
+{{ states(browser_entities.currentUser.entity_id) if 'currentUser' in browser_entities else 'unknown' }}
 ```
 
 Example: Get the first part of the Browser path
 ```yaml
-{{ state_attr(browser_entities.path, 'pathSegments')[1] }}
+{{ state_attr(browser_entities.panel.entity_id, 'viewTitle') if 'panel' in browser_entities else 'unknown' }}
 ```
 
 ---

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -54,7 +54,7 @@ As settings here may mean you get yourself locked out of Browser Mod panel in so
 
 ### Title template
 
-This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/). Vairables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
+This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/). Variables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
 
 > Ex:
 >

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -191,7 +191,7 @@ Set the order and hidden items of the sidebar. To change this setting:
 ### Sidebar title
 
 This changes the "Home Assistant" text that is displayed at the top of the sidebar.
-Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). Vairables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
+Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). Variables available are `browser_id` and [`browser_entities`](#browser-entities-variable) (undefined if Browser not registered).
 
 ### Hide interaction icon
 

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -222,7 +222,7 @@ Using this method means that the new random Browser ID never has sent informatio
 
 The variable `browser_entities` is available in templates. It is a dictionary of the entities for the Browser and includes the following.
 
-> NOTE: If the Browser is not regsitered, `browser_entities` will be undefined. Your template should use `default()`to handle such a case.
+> NOTE: If the Browser is not registered, `browser_entities` will be undefined. Your template should use `default()` to handle such a case.
 
 | Variable | Sensor | Example |
 |---|---|---|

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -54,7 +54,7 @@ As settings here may mean you get yourself locked out of Browser Mod panel in so
 
 ### Title template
 
-This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/).
+This allows you to set and dynamically update the title text of the browser tab/window by means on a Jinja [template](https://www.home-assistant.io/docs/configuration/templating/). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
 
 > Ex:
 >
@@ -64,7 +64,7 @@ This allows you to set and dynamically update the title text of the browser tab/
 
 ### Favicon template
 
-This allows you to set and dynamically update the favicon of the browser tab/window. I.e. the little icon next to the page title. Favicons can be .png or .ico files and should be placed in your `<config>/www` directory. The box here should then contain a jinja [template](https://www.home-assistant.io/docs/configuration/templating/) which resolves to the path of the icon with `<config>/www/` replaced by `/local/` (see [Hosting files](https://www.home-assistant.io/integrations/http/#hosting-files)).
+This allows you to set and dynamically update the favicon of the browser tab/window. I.e. the little icon next to the page title. Favicons can be .png or .ico files and should be placed in your `<config>/www` directory. The box here should then contain a jinja [template](https://www.home-assistant.io/docs/configuration/templating/) which resolves to the path of the icon with `<config>/www/` replaced by `/local/` (see [Hosting files](https://www.home-assistant.io/integrations/http/#hosting-files)). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
 
 > Ex:
 >
@@ -191,7 +191,7 @@ Set the order and hidden items of the sidebar. To change this setting:
 ### Sidebar title
 
 This changes the "Home Assistant" text that is displayed at the top of the sidebar.
-Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). Variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
+Accepts Jinja [templates](https://www.home-assistant.io/docs/configuration/templating/). If the Browser is registered, variables available are `browser_id` and [`browser_entities`](#browser-entities-variable).
 
 ### Hide interaction icon
 

--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -73,7 +73,7 @@ export const ConnectionMixin = (SuperClass) => {
     }
 
     private async entitiesReady() {
-      if (this.ready && !this.registered) return true;
+      if (this.ready && !this.registered) return false;
       if (Object.keys(this.browserEntities).length > 0) {
         return true;
       } else {
@@ -82,7 +82,7 @@ export const ConnectionMixin = (SuperClass) => {
           await new Promise(resolve => setTimeout(resolve, 500));
           if (this.ready && !this.registered) return true;
         }
-        if (Object.keys(this.browserEntities).length > 0) return true;
+        if (Object.keys(this.browserEntities).length > 0) return false;
         throw new Error("Browser entities not available after 10 seconds");
       }
     }

--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -73,12 +73,14 @@ export const ConnectionMixin = (SuperClass) => {
     }
 
     private async entitiesReady() {
+      if (this.ready && !this.registered) return true;
       if (Object.keys(this.browserEntities).length > 0) {
         return true;
       } else {
         let cnt = 0;
         while (Object.keys(this.browserEntities).length === 0 && cnt++ < 20) {
           await new Promise(resolve => setTimeout(resolve, 500));
+          if (this.ready && !this.registered) return true;
         }
         if (Object.keys(this.browserEntities).length > 0) return true;
         throw new Error("Browser entities not available after 10 seconds");

--- a/js/plugin/connection.ts
+++ b/js/plugin/connection.ts
@@ -80,9 +80,9 @@ export const ConnectionMixin = (SuperClass) => {
         let cnt = 0;
         while (Object.keys(this.browserEntities).length === 0 && cnt++ < 20) {
           await new Promise(resolve => setTimeout(resolve, 500));
-          if (this.ready && !this.registered) return true;
+          if (this.ready && !this.registered) return false;
         }
-        if (Object.keys(this.browserEntities).length > 0) return false;
+        if (Object.keys(this.browserEntities).length > 0) return true;
         throw new Error("Browser entities not available after 10 seconds");
       }
     }


### PR DESCRIPTION
Fix 2 console warnings when Browser not registered.

Note: 

1. If Browser not registered then player will not be enabled and no interaction. This is correct as without a media_player there is no need to have interaction.
2. If Browser is not registered then global Frontend settings will apply as per existing. However `browser_id` and `browser_entities` in settings template will be undefined. Documentation notes this.