### PR TITLE
New service browser_mod.change_browser_id

### DIFF
--- a/custom_components/browser_mod/const.py
+++ b/custom_components/browser_mod/const.py
@@ -27,6 +27,7 @@ BROWSER_MOD_BROWSER_SERVICES = [
     "notification",
     "navigate",
     "refresh",
+    "change_browser_id",
     "set_theme",
     "console",
     "javascript",

--- a/custom_components/browser_mod/services.yaml
+++ b/custom_components/browser_mod/services.yaml
@@ -369,6 +369,35 @@ refresh:
           filter:
             domain: "person"
 
+change_browser_id:
+  name: change_browser_id
+  description: "Change browser ID" 
+  fields:
+    current_browser_id:
+      name: Current Browser ID
+      description: "Current Browser ID of the browser to change"
+      selector:
+        device:
+          multiple: false
+          filter:
+            integration: "browser_mod"
+    new_browser_id:
+      name: New ID
+      description: "New Browser ID for the browser"
+      selector:
+        text:
+    register:
+      name: Register
+      description: "Register the browser"
+      selector:
+        boolean:
+    refresh:
+      name: Refresh
+      description: "Refresh the browser after changing the ID"
+      default: true
+      selector:
+        boolean:
+
 set_theme:
   name: set_theme
   description: "Change the current theme"

--- a/documentation/services.md
+++ b/documentation/services.md
@@ -138,6 +138,28 @@ data:
   [user_id: <User IDs>]
 ```
 
+## `browser_mod.rename_browser`
+
+Change a Browser ID.
+
+```yaml
+service: browser_mod.change_browser_id
+data:
+  [current_browser_id: <string>]
+  [new_browser_id: <string>]
+  [register: <true|FALSE>]
+  [refresh: <TRUE|false>]
+```
+
+| | |
+|---|---|
+|`current_browser_id`| The Browser ID of the Browser to change. This is not the usual `browser_id` parameter as only a single Browser ID is supported for `browser_modchange_browser_idr`. |
+|`new_browser_id`| The new Browser ID for the Browser. |
+|`register`| If true, register the Browser after rename. |
+|`refresh`| If true, refresh the browser after rename. |
+
+> NOTE: Browser IDs are changed on the Browser. When this service is called as a [*Server* call](services.md#calling-services---server-call-vs-browser-call), it will send the change request to all registered Browsers and if `current_browser_id` matches the browser's Browser ID, it will perform the change. When this service is called as a [*Browser* call](services.md#calling-services---server-call-vs-browser-call), `current_browser_id` is still required to confirm the Browser ID change. If you wish for an interactive popup to change the Browser ID, call `browser_mod.change_browser_id` leaving all parameters empty. The interactive approach should only be taken when calling as a [*Browser* call](services.md#calling-services---server-call-vs-browser-call) as leaving all parameters empty with a [*Server* call](services.md#calling-services---server-call-vs-browser-call) will show the interactive Browser ID change popup on **ALL** registered Browsers.
+
 ## `browser_mod.more_info`
 
 Show a more-info dialog.

--- a/js/plugin/services.ts
+++ b/js/plugin/services.ts
@@ -15,6 +15,7 @@ export const ServicesMixin = (SuperClass) => {
         "notification",
         "navigate",
         "refresh",
+        "change_browser_id",
         "set_theme",
         "console",
         "javascript",
@@ -188,6 +189,78 @@ export const ServicesMixin = (SuperClass) => {
               window.location.reload();
             } else {
               window.location.href = window.location.href;
+            }
+          }
+          break;
+
+        case "change_browser_id":
+          {
+            const { current_browser_id, new_browser_id, register, refresh } = data;
+            if (current_browser_id === undefined && new_browser_id === undefined) {
+              const title = "Change Browser ID";
+              const content = [
+                { 
+                  name: "current_browser_id", 
+                  label: "Current Browser ID", 
+                  selector: { text: null },
+                  default: this.browserID,
+                  disabled: true,
+                },
+                { 
+                  name: "new_browser_id", 
+                  label: "New Browser ID", 
+                  selector: { text: null },
+                },
+                {
+                  name: "register",
+                  label: "Register",
+                  selector: {
+                    boolean: null
+                  },
+                  default: this.registered,
+                },
+                {
+                  name: "refresh",
+                  label: "Refresh",
+                  selector: {
+                    boolean: null
+                  },
+                  default: refresh ?? true,
+                }
+              ];
+              const buttons = {
+                left_button: "Cancel",
+                right_button: "Change",
+                right_button_variant: "danger",
+                right_button_appearance: "accent",
+                right_button_action: (form_data) => {
+                  this.fireBrowserEvent("command-change_browser_id", form_data);
+                }
+              };
+              window.browser_mod?.showPopup({ title, content, ...buttons });
+            } else {
+              let match = false;
+              if (current_browser_id && this.browserID === current_browser_id) {
+                match = true;
+              } else if (this.hass?.devices[current_browser_id]?.identifiers[0].includes(this.browserID)) {
+                match = true;
+              }
+              if (match) {
+                if (new_browser_id && typeof new_browser_id === "string") {
+                  const trimmed_new_browser_id = new_browser_id.trim();
+                  if (trimmed_new_browser_id !== "" && trimmed_new_browser_id !== this.browserID) {
+                    this.browserID = trimmed_new_browser_id;
+                  }
+                }
+                if (register !== undefined && this.registered !== register) {
+                  this.registered = register;
+                }
+                if (refresh) {
+                  window.setTimeout(() => {
+                    this.fireBrowserEvent("command-refresh", {});
+                  }, 100);
+                }
+              }
             }
           }
           break;


### PR DESCRIPTION
Now Browser Mod settings are locked for non-admins, this gives admins a service to use as an alternative having to logout of device just to change Browser ID.