### PR TITLE
Allow to style media_player popup via extra data

### DIFF
--- a/js/plugin/mediaPlayer.ts
+++ b/js/plugin/mediaPlayer.ts
@@ -121,8 +121,9 @@ export const MediaPlayerMixin = (SuperClass) => {
           title: undefined,
           content: this._video_player,
           dismiss_action: () => this._video_player.pause(),
-          size: "wide",
+          initial_style: "wide",
           tag: "media_player",
+          ...this.extra?.popup
         });
       } else if (
         this.player !== this._video_player &&


### PR DESCRIPTION
Allows for a non padded fullscreen video. While this could be the default it would be breaking. Perhaps once this is availbale and we get lots of feedback on what should be default then we could update.

```yaml
action: media_player.play_media
data:
  extra:
    popup:
      initial_style: fullscreen
      popup_styles:
        - style: all
          styles: |
            ha-dialog .container {
              padding: 0px;
            }
  media:
    media_content_id: media-source://media_source/local/BigBuckBunny.mp4
    media_content_type: video/mp4
target:
  entity_id: media_player.dcd_browser
```