### PR TITLE
Add browserID sensor

### DIFF
--- a/custom_components/browser_mod/browser.py
+++ b/custom_components/browser_mod/browser.py
@@ -69,6 +69,7 @@ class BrowserModBrowser:
             adder([new])
             self.entities[name] = new
 
+        _assert_browser_sensor("sensor", "browserID", "Browser ID", icon="mdi:server")
         _assert_browser_sensor("sensor", "path", "Browser path", icon="mdi:web")
         _assert_browser_sensor("sensor", "visibility", "Browser visibility")
         _assert_browser_sensor(

--- a/custom_components/browser_mod/sensor.py
+++ b/custom_components/browser_mod/sensor.py
@@ -34,6 +34,8 @@ class BrowserSensor(BrowserModEntity, SensorEntity):
 
     @property
     def native_value(self):
+        if self.parameter == "browserID":
+            return self.browserID
         val = self._data.get("browser", {}).get(self.parameter, None)
         if len(str(val)) > 255:
             val = str(val)[:250] + "..."

--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -240,6 +240,7 @@ The variable `browser_entities` is available in Frontend settings templates. It 
 
 | Variable | Sensor | Example |
 |---|---|---|
+| `browser_entities.browserID` | Browser ID Sensor | _sensor.browser_id_ |
 | `browser_entities.path` | Browser path Sensor | _sensor.browser_id_browser_path_ |
 | `browser_entities.visibility` | Browser visibility Sensor | _sensor.browser_id_browser_visibility_ |
 | `browser_entities.userAgent` | Browser userAgent Sensor | _sensor.browser_id_browser_useragent_ |


### PR DESCRIPTION
Makes sense to have a BrowserID sensor. While it is an attribute of every sensor, with planned Browser Mod Tile and Badge cards, having it as its own sensor makes it easily accessible for new Browser Mod users. Also, means easier access when using `browser_entities`.