### PR TITLE
Update legacy dashboard Frontend setting section with recommendations

### DIFF
--- a/documentation/configuration-panel.md
+++ b/documentation/configuration-panel.md
@@ -137,7 +137,7 @@ __IMPORTANT__: Like actions popups and notifications, this setting DOES NOT supp
 
 1. Global/System ⇒ (Since 2025.12) Set the Home Assistant default system dashboard in Dashboards.
 2. Browser/Device ⇒ Use Default action with `browser_mod.navigate`. This also works with other pages than lovelace dashboards, like e.g. `logbook` or even `history?device_id=f112fd806f2520c76318406f98cd244e&start_date=2022-09-02T16%3A00%3A00.000Z&end_date=2022-09-02T19%3A00%3A00.000Z`.
-3. User ⇒ (Since 2025.12) Set Home Assistant default user Dashboard in user profile.
+3. User ⇒ (Since 2025.12) Set Home Assistant default user dashboard in user profile.
 
 Set the default dashboard that is shown when you access `https://<your home assistant url>/` with nothing after the `/`.
 


### PR DESCRIPTION
Clarify the usage of the legacy default dashboard setting and provide recommended alternatives for setting the default dashboard in Home Assistant.

PR created against master to be merged when 2025.12 is released.