### PR TITLE
Fix console error and badge availability when window.customBadges does not exist.

### DIFF
--- a/js/plugin/dashboard-cards/badge.ts
+++ b/js/plugin/dashboard-cards/badge.ts
@@ -173,6 +173,7 @@ window.addEventListener("browser-mod-bootstrap", async (ev: CustomEvent) => {
 
   if (!customElements.get("browser-mod-badge")) {
     customElements.define("browser-mod-badge", BrowserModBadge);
+    (window as any).customBadges = (window as any).customBadges || [];
     (window as any).customBadges.push({
       type: "browser-mod-badge",
       name: "Browser Mod Badge",


### PR DESCRIPTION
Only beta issue as this feature is yet to be released.