### PR TITLE
fix: Allow for removal of ha-settings-row

### DIFF
--- a/js/config_panel/browser-settings-card.ts
+++ b/js/config_panel/browser-settings-card.ts
@@ -3,7 +3,7 @@ import { property, state } from "lit/decorators.js";
 
 class BrowserModRegisteredBrowsersCard extends LitElement {
   @property() hass;
-  @property() dirty = false;
+  @property({ type: Boolean }) dirty = false;
   @property({ type: Boolean }) public narrow = false;
 
   toggleRegister() {
@@ -68,12 +68,13 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
             : ""}
         </div>
         <div class="card-content">
-          <ha-settings-row>
-            <span slot="heading">Register</span>
-            <span slot="description"
+          <ha-md-list-item>
+            <span slot="headline">Register</span>
+            <span slot="supporting-text"
               >Enable this browser as a Device in Home Assistant</span
             >
             <ha-switch
+              slot="end"
               .checked=${window.browser_mod?.registered}
               @change=${this.toggleRegister}
               .disabled=${window.browser_mod?.browser_locked ||
@@ -81,14 +82,15 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
               window.browser_mod?.global_settings["lockRegister"] ||
               !this.hass.user?.is_admin }
             ></ha-switch>
-          </ha-settings-row>
+          </ha-md-list-item>
 
-          <ha-settings-row .narrow=${this.narrow}>
-            <span slot="heading">Browser ID</span>
-            <span slot="description"
+          <ha-md-list-item ?narrow=${this.narrow}>
+            <span slot="headline">Browser ID</span>
+            <span slot="supporting-text"
               >A unique identifier for this browser-device combination.</span
             >
             <ha-form
+              slot="end"
               .hass=${this.hass}
               .schema=${[
                 {
@@ -122,23 +124,24 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
               }}
             >
             </ha-form>
-          </ha-settings-row>
+          </ha-md-list-item>
 
           ${window.browser_mod?.registered
             ? html`
                 ${this._renderSuspensionAlert()}
-                <ha-settings-row>
-                  <span slot="heading">Enable camera</span>
-                  <span slot="description"
+                <ha-md-list-item>
+                  <span slot="headline">Enable camera</span>
+                  <span slot="supporting-text"
                     >Get camera input from this browser (hardware
                     dependent)</span
                   >
                   <ha-switch
+                    slot="end"
                     .checked=${window.browser_mod?.cameraEnabled}
                     @change=${this.toggleCameraEnabled}
                     .disabled=${window.browser_mod?.browser_locked}
                   ></ha-switch>
-                </ha-settings-row>
+                </ha-md-list-item>
                 ${window.browser_mod?.cameraError
                   ? html`
                       <ha-alert alert-type="error">
@@ -300,6 +303,9 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
       ha-textfield {
         display: block;
         margin-top: 8px;
+      }
+      ha-md-list-item[narrow] > ha-form {
+        flex: 2;
       }
     `;
   }

--- a/js/config_panel/frontend-settings-card.ts
+++ b/js/config_panel/frontend-settings-card.ts
@@ -175,11 +175,11 @@ class BrowserModFrontendSettingsCard extends LitElement {
                   .secondary=${"Nothing to see here"}
                   leftChevron
                 >
-                  <ha-settings-row>
-                    <span slot="heading" id="afj_heading"
+                  <ha-md-list-item>
+                    <span slot="headline" id="afj_heading"
                       >Allow April Fool's jokes</span
                     >
-                    <span slot="description" id="afj_description">
+                    <span slot="supporting-text" id="afj_description">
                       By enabling this, I consent to any April Fool's Jokes
                       messing with my frontend.
                     </span>
@@ -190,11 +190,12 @@ class BrowserModFrontendSettingsCard extends LitElement {
                       It's just a toggle connected to nothing."
                     ></span>
                     <ha-switch
+                      slot="end"
                       id="afj"
                       .checked=${true}
                       @change=${this._toggle_afj}
                     ></ha-switch>
-                  </ha-settings-row>
+                  </ha-md-list-item>
                 </ha-expansion-panel>
               `
             : ``}
@@ -371,22 +372,23 @@ class BrowserModFrontendSettingsCard extends LitElement {
             >
               ${this._hassUserHasSidebarSettings ? 
                 html`
-                <ha-settings-row>
-                  <span slot="heading">Sidebar user settings</span>
-                  <div slot="description" style="display: flex;">
+                <ha-md-list-item>
+                  <span slot="headline">Sidebar user settings</span>
+                  <div slot="supporting-text" style="display: flex;">
                     <span>
                     This user has sidebar settings synced to Home Assistant user profile. 
                     It is recommend to clear these settings to allow Browser Mod settings to 
                     take precedence. To check other Home Assistant users, login as that user
                     and check back at this panel.
                     </span>
-                    <ha-button
-                      variant="danger"
-                      appearance="filled"
-                      @click=${() => this.clearHassUserSidebarSettings()}
-                    >Clear</ha-button>
                   </div>
-                </ha-settings-row>` 
+                  <ha-button
+                    slot="end"
+                    variant="danger"
+                    appearance="filled"
+                    @click=${() => this.clearHassUserSidebarSettings()}
+                  >Clear</ha-button>
+                </ha-md-list-item>` 
                 : "" 
               }
               <browser-mod-settings-table
@@ -408,8 +410,8 @@ class BrowserModFrontendSettingsCard extends LitElement {
             @expanded-changed=${this.expandedChanged}
             leftChevron
           >
-            <ha-settings-row>
-              <ol slot="heading">
+            <ha-md-list-item>
+              <ol slot="headline">
                 <li>Click EDIT</li>
                 <li>Set up the sidebar as you want it</li>
                 <li>Do NOT click DONE</li>
@@ -417,11 +419,12 @@ class BrowserModFrontendSettingsCard extends LitElement {
                 <li>Click RESTORE</li>
               </ol>
               <ha-button
+                slot="end"
                 appearance="plain"
                 @click=${() => this.toggleEditSidebar()}>
                   ${this._editSidebar ? "Restore" : "Edit"}
               </ha-button>
-            </ha-settings-row>
+            </ha-md-list-item>
             <browser-mod-settings-table
               .hass=${this.hass}
               .settingKey=${"sidebarPanelOrder"}

--- a/js/config_panel/registered-browsers-card.ts
+++ b/js/config_panel/registered-browsers-card.ts
@@ -102,37 +102,39 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
     return html`
       <ha-card header="Registered Browsers" outlined>
         <div class="card-content">
-          <ha-settings-row>
-            <span slot="heading">Auto-register</span>
-            <span slot="description">
+          <ha-md-list-item>
+            <span slot="headline">Auto-register</span>
+            <span slot="supporting-text">
               Automatically register all new Browsers
             </span>
             <ha-switch
+              slot="end"
               .checked=${window.browser_mod?.global_settings["autoRegister"] ===
               true}
               @change=${this.toggle_auto_register}
             ></ha-switch>
-          </ha-settings-row>
-          <ha-settings-row>
-            <span slot="heading">Lock register</span>
-            <span slot="description">
+          </ha-md-list-item>
+          <ha-md-list-item>
+            <span slot="headline">Lock register</span>
+            <span slot="supporting-text">
               Disable registering or unregistering of all Browsers
             </span>
             <ha-switch
+              slot="end"
               .checked=${window.browser_mod?.global_settings["lockRegister"] ===
               true}
               @change=${this.toggle_lock_register}
             ></ha-switch>
-          </ha-settings-row>
+          </ha-md-list-item>
 
           ${Object.keys(window.browser_mod.browsers).map((d) => {
             const browser = window.browser_mod.browsers[d];
             const device = this._find_entity(d);
-            return html` <ha-settings-row>
-              <span slot="heading">
+            return html` <ha-md-list-item>
+              <span slot="headline">
                 ${d} ${device?.name_by_user ? `(${device.name_by_user})` : ""}
               </span>
-              <span slot="description">
+              <span slot="supporting-text">
                 Last connected:
                 <ha-relative-time
                   .hass=${this.hass}
@@ -141,14 +143,14 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
               </span>
               ${device
                 ? html`
-                    <a href="config/devices/device/${device.id}">
+                    <a href="config/devices/device/${device.id}" slot="end">
                       <ha-icon-button>
                         <ha-icon .icon=${"mdi:devices"}></ha-icon>
                       </ha-icon-button>
                     </a>
                   `
                 : ""}
-              <ha-icon-button
+              <ha-icon-button slot="end"
                 .browserID=${d}
                 @click=${this.toggle_lock_browser}
               >
@@ -156,10 +158,10 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
                   .icon=${browser.locked ? "mdi:lock" : "mdi:lock-open-variant"}
                 ></ha-icon>
               </ha-icon-button>
-              <ha-icon-button .browserID=${d} @click=${this.unregister_browser}>
+              <ha-icon-button slot="end" .browserID=${d} @click=${this.unregister_browser}>
                 <ha-icon .icon=${"mdi:delete"}></ha-icon>
               </ha-icon-button>
-            </ha-settings-row>`;
+            </ha-md-list-item>`;
           })}
         </div>
         ${window.browser_mod.browsers["CAST"] === undefined
@@ -183,6 +185,9 @@ class BrowserModRegisteredBrowsersCard extends LitElement {
       ha-icon-button > * {
         display: flex;
         color: var(--primary-text-color);
+      }
+      ha-card .card-content {
+        --ha-md-list-item-gap: var(--ha-space-2);
       }
     `;
   }

--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -143,7 +143,7 @@ export const loadHaForm = async () => {
 };
 
 // Loads in ha-config-dashboard which is used to copy styling
-// Also provides ha-settings-row
+// Also provides ha-md-list-item
 export const loadConfigDashboard = async () => {
   await customElements.whenDefined("partial-panel-resolver");
   const ppResolver = document.createElement("partial-panel-resolver");
@@ -157,8 +157,7 @@ export const loadConfigDashboard = async () => {
   await customElements.whenDefined("ha-panel-config");
   const configRouter: any = document.createElement("ha-panel-config");
   await configRouter?.routerOptions?.routes?.dashboard?.load?.(); // Load ha-config-dashboard
-  await configRouter?.routerOptions?.routes?.general?.load?.(); // Load ha-settings-row
-  await configRouter?.routerOptions?.routes?.entities?.load?.(); // Load ha-data-table
+  await configRouter?.routerOptions?.routes?.network?.load?.(); // Load ha-md-list-item
   await customElements.whenDefined("ha-config-dashboard");
 };
 


### PR DESCRIPTION
ha-settings-row may be getting removed. This PR is ready with updates for Browser Mod panel.

Also removes load of entities config panel as ha-data-table is no longer used.

Uses network config panel which will use of ha-md-list-item as of 2026.3 (or perhaps 2026.2.x, x > 1 ?).