### PR TITLE
Fix slider in browser-player card

### DIFF
--- a/js/plugin/browser-player.ts
+++ b/js/plugin/browser-player.ts
@@ -141,9 +141,9 @@ class BrowserPlayer extends LitElement {
           </ha-icon-button>
           <ha-slider
             labeled
-            .min="0"
-            .max="100"
-            .step="1"
+            .min=${0}
+            .max=${100}
+            .step=${1}
             .disabled=${window.browser_mod.player.muted}
             .value=${window.browser_mod.player.volume * 100}
             @change=${this.handleVolumeChange}


### PR DESCRIPTION
Hi,
I noticed that since Home Assistant frontend migrated the ha-slider to webawesome in September last year, the volume slider in the browser-player card did not properly update its position. This PR fixes it.
Best regards