### PR TITLE
chore(ci): add semantic-release dry-run input and align workflow acti…

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v6"
         - uses: home-assistant/actions/hassfest@master 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,13 @@
 name: Release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run semantic-release in dry-run mode"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -13,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
 
@@ -28,4 +35,9 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: |
+          DRY_RUN_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          npx semantic-release $DRY_RUN_FLAG


### PR DESCRIPTION
…ons to v6 (#1292)

* ci: update checkout and add semantic-release dry-run input

Agent-Logs-Url: https://github.com/thomasloven/hass-browser_mod/sessions/5792c9ce-db29-4ce7-91f2-548df49c9c42



* ci: simplify semantic-release dry-run command wiring

Agent-Logs-Url: https://github.com/thomasloven/hass-browser_mod/sessions/5792c9ce-db29-4ce7-91f2-548df49c9c42



* ci: bump checkout and setup-node to v6

Agent-Logs-Url: https://github.com/thomasloven/hass-browser_mod/sessions/ac42852c-b976-4f67-a164-ad8439a602f1



---------