### PR TITLE
fix: Workaround iFrames in popup causing double history state by setting dialog addHistory option to false when content contains iFrame. Without this workaround, interacting with iFrame will cause any Home Assistant dialog not to open after popup is closed.

### DIFF
--- a/js/helpers.ts
+++ b/js/helpers.ts
@@ -257,6 +257,46 @@ export async function waitRepeat(fn, times, delay) {
   }
 }
 
+const IFRAME_TYPE = "iframe";
+
+function isIframeType(value: unknown): boolean {
+  return typeof value === "string" && value.toLowerCase() === IFRAME_TYPE;
+}
+
+export function popupContentContainsIframe(content: unknown): boolean {
+  if (content == null || content === false) return false;
+  if (content instanceof HTMLElement) {
+    if (isIframeType(content.tagName)) {
+      return true;
+    }
+    for (const child of content.children) {
+      if (popupContentContainsIframe(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (typeof content === "string") {
+    return /<iframe[\s>]/i.test(content);
+  }
+  if (Array.isArray(content)) {
+    return content.some((item) => popupContentContainsIframe(item));
+  }
+  if (typeof content === "object" && !Array.isArray(content)) {
+    const objectContent = content as Record<string, unknown>;
+    if (isIframeType(objectContent.type)) {
+      return true;
+    }
+    for (const key of Object.keys(objectContent)) {
+      if (key === "type") continue;
+      if (popupContentContainsIframe(objectContent[key])) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 export function blankVideoUrl() {
   return "data:video/mp4;base64,AAAAGGZ0eXBpc29tAAAAAGlzb21tcDQxAAAACGZyZWUAAAAmbWRhdCELUCh9wBQ+4cAhC1AAfcAAPuHAIQtQAH3AAD7hwAAAAlNtb292AAAAbG12aGQAAAAAxzFHd8cxR3cAAV+QAAAYfQABAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAG2lvZHMAAAAAEA0AT////xX/DgQAAAACAAABxHRyYWsAAABcdGtoZAAAAAfHMUd3xzFHdwAAAAIAAAAAAAAYfQAAAAAAAAAAAAAAAAEAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAWBtZGlhAAAAIG1kaGQAAAAAxzFHd8cxR3cAAKxEAAAL/xXHAAAAAAA0aGRscgAAAAAAAAAAc291bgAAAAAAAAAAAAAAAFNvdW5kIE1lZGlhIEhhbmRsZXIAAAABBG1pbmYAAAAQc21oZAAAAAAAAAAAAAAAJGRpbmYAAAAcZHJlZgAAAAAAAAABAAAADHVybCAAAAABAAAAyHN0YmwAAABkc3RzZAAAAAAAAAABAAAAVG1wNGEAAAAAAAAAAQAAAAAAAAAAAAIAEAAAAACsRAAAAAAAMGVzZHMAAAAAA4CAgB8AQBAEgICAFEAVAAYAAAANdQAADXUFgICAAhIQBgECAAAAGHN0dHMAAAAAAAAAAQAAAAMAAAQAAAAAHHN0c2MAAAAAAAAAAQAAAAEAAAADAAAAAQAAABRzdHN6AAAAAAAAAAoAAAADAAAAFHN0Y28AAAAAAAAAAQAAACg=";
 }

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -3,6 +3,7 @@ import {
   loadLoadCardHelpers,
   hass_base_el,
   BROWSER_MOD_CLOSE_ANCHOR,
+  popupContentContainsIframe,
 } from "../helpers";
 import { BrowserModPopup } from "./popup-dialog";
 
@@ -212,14 +213,14 @@ export const showBrowserModPopup = (
   BrowserModPopupParams: BrowserModPopupParams
 ): void => {
   setCustomElementClass(dialogTag);
-  const addHistory = JSON.stringify(BrowserModPopupParams.content ?? {}).includes("iframe") ? false : true;
+  const addHistory = !popupContentContainsIframe(BrowserModPopupParams.content);
   element.dispatchEvent(
     new CustomEvent("show-dialog", {
       detail: {
         dialogTag,
         dialogImport: () => { return customElements.whenDefined(dialogTag) },
         dialogParams: BrowserModPopupParams,
-        addHistory: addHistory,
+        addHistory,
       }
     })
   );

--- a/js/plugin/popups.ts
+++ b/js/plugin/popups.ts
@@ -212,12 +212,14 @@ export const showBrowserModPopup = (
   BrowserModPopupParams: BrowserModPopupParams
 ): void => {
   setCustomElementClass(dialogTag);
+  const addHistory = JSON.stringify(BrowserModPopupParams.content ?? {}).includes("iframe") ? false : true;
   element.dispatchEvent(
     new CustomEvent("show-dialog", {
       detail: {
         dialogTag,
         dialogImport: () => { return customElements.whenDefined(dialogTag) },
         dialogParams: BrowserModPopupParams,
+        addHistory: addHistory,
       }
     })
   );


### PR DESCRIPTION
Fixes #1297 