### PR TITLE
fix: serve frontend scripts with always-revalidate caching (ends version-mismatch toast loop)

### DIFF
--- a/custom_components/browser_mod/mod_view.py
+++ b/custom_components/browser_mod/mod_view.py
@@ -1,49 +1,129 @@
-from homeassistant.core import HomeAssistant
+from dataclasses import dataclass
+from functools import cache
+from hashlib import sha256
+from pathlib import Path
+
+from aiohttp import web
+
 from homeassistant.components.frontend import (
     add_extra_js_url,
     async_register_built_in_panel,
     async_remove_panel,
     remove_extra_js_url,
 )
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.lovelace.resources import ResourceStorageCollection
+from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, FRONTEND_SCRIPT_URL, BROWSER_PANEL_URL, CONFIG_PANEL_URL
-from .helpers import get_version
+from .const import (
+    BROWSER_PANEL_URL,
+    CONFIG_PANEL_URL,
+    DATA_STORE,
+    DOMAIN,
+    FRONTEND_SCRIPT_URL,
+)
 
-import logging
-
-_LOGGER = logging.getLogger(__name__)
 FRONTEND_SETTINGS_PANEL_PATH = "browser-mod"
 CONFIG_PANEL_PATH = "browser-mod-config"
+_DATA_FRONTEND_SCRIPT_URL = "frontend_script_url"
+_DATA_FRONTEND_VIEW_REGISTERED = "frontend_view_registered"
+
+
+@dataclass(frozen=True)
+class _FrontendScript:
+    body: bytes
+    etag: str
+
+
+@dataclass(frozen=True)
+class _FrontendSnapshot:
+    scripts: dict[str, _FrontendScript]
+    revision: str
+
+
+@cache
+def _load_frontend_snapshot(
+    config_dir: str, runtime_version: str
+) -> _FrontendSnapshot:
+    """Load the frontend that belongs to this Python process.
+
+    The cache intentionally lasts for the lifetime of the imported Python
+    module. HACS may replace the files on disk before Home Assistant restarts,
+    but the running backend must continue serving the frontend it started
+    with. A restart imports this module again and creates a new snapshot.
+    """
+    component_dir = Path(config_dir) / "custom_components" / "browser_mod"
+    script_files = {
+        FRONTEND_SCRIPT_URL: component_dir / "browser_mod.js",
+        BROWSER_PANEL_URL: component_dir / "browser_mod_browser_panel.js",
+        CONFIG_PANEL_URL: component_dir / "browser_mod_config_panel.js",
+    }
+
+    revision = sha256(runtime_version.encode())
+    scripts = {}
+    for url, path in script_files.items():
+        body = path.read_bytes()
+        digest = sha256(body).hexdigest()
+        scripts[url] = _FrontendScript(body=body, etag=digest)
+        revision.update(url.encode())
+        revision.update(body)
+
+    return _FrontendSnapshot(
+        scripts=scripts,
+        revision=revision.hexdigest()[:16],
+    )
+
+
+class BrowserModScriptView(HomeAssistantView):
+    """Serve a process-lifetime snapshot of the Browser Mod frontend."""
+
+    requires_auth = False  # module scripts are fetched without auth headers
+    url = FRONTEND_SCRIPT_URL
+    name = "browser_mod:frontend"
+    extra_urls = [BROWSER_PANEL_URL, CONFIG_PANEL_URL]
+
+    def __init__(self, snapshot: _FrontendSnapshot):
+        self._scripts = snapshot.scripts
+
+    async def get(self, request: web.Request) -> web.Response:
+        script = self._scripts.get(request.path)
+        if script is None:
+            raise web.HTTPNotFound()
+
+        headers = {
+            "Cache-Control": "no-cache",
+            "ETag": f'"{script.etag}"',
+        }
+        if request.if_none_match and any(
+            etag.value in ("*", script.etag) for etag in request.if_none_match
+        ):
+            return web.Response(status=304, headers=headers)
+
+        return web.Response(
+            body=script.body,
+            content_type="text/javascript",
+            headers=headers,
+        )
+
 
 async def async_setup_view(hass: HomeAssistant):
-
-    version = await hass.async_add_executor_job(get_version, hass)
-    frontend_script_url = FRONTEND_SCRIPT_URL + "?" + version
-
-    # Serve the Browser Mod controller and add it as extra_module_url
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                FRONTEND_SCRIPT_URL,
-                hass.config.path("custom_components/browser_mod/browser_mod.js"),
-                True,
-            )
-        ]
+    runtime_version = hass.data[DOMAIN][DATA_STORE].get_version()
+    snapshot = await hass.async_add_executor_job(
+        _load_frontend_snapshot,
+        hass.config.config_dir,
+        runtime_version,
     )
+    frontend_script_url = FRONTEND_SCRIPT_URL + "?" + snapshot.revision
+
+    # Serve the scripts captured by this backend process. The content revision
+    # changes only after a restart loads a new frontend snapshot.
+    if not hass.data[DOMAIN].get(_DATA_FRONTEND_VIEW_REGISTERED):
+        hass.http.register_view(BrowserModScriptView(snapshot))
+        hass.data[DOMAIN][_DATA_FRONTEND_VIEW_REGISTERED] = True
     add_extra_js_url(hass, frontend_script_url)
+    hass.data[DOMAIN][_DATA_FRONTEND_SCRIPT_URL] = frontend_script_url
 
-    # Serve the Browser Mod Browser Panel and register it as a panel
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                BROWSER_PANEL_URL,
-                hass.config.path("custom_components/browser_mod/browser_mod_browser_panel.js"),
-                True,
-            )
-        ]
-    )
+    # Register the Browser Mod Browser Panel
     async_remove_panel(hass, FRONTEND_SETTINGS_PANEL_PATH, warn_if_unknown=False)
     async_register_built_in_panel(
         hass=hass,
@@ -55,21 +135,12 @@ async def async_setup_view(hass: HomeAssistant):
         config={
             "_panel_custom": {
                 "name": "browser-mod-browser-panel",
-                "module_url": BROWSER_PANEL_URL + "?" + version,
+                "module_url": BROWSER_PANEL_URL + "?" + snapshot.revision,
             }
         },
     )
 
-    # Serve the Browser Mod Config panel and register it as a panel
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                CONFIG_PANEL_URL,
-                hass.config.path("custom_components/browser_mod/browser_mod_config_panel.js"),
-                True,
-            )
-        ]
-    )
+    # Register the Browser Mod Config panel
     async_remove_panel(hass, CONFIG_PANEL_PATH, warn_if_unknown=False)
     async_register_built_in_panel(
         hass=hass,
@@ -80,14 +151,19 @@ async def async_setup_view(hass: HomeAssistant):
         config={
             "_panel_custom": {
                 "name": "browser-mod-config-panel",
-                "module_url": CONFIG_PANEL_URL + "?" + version,
+                "module_url": CONFIG_PANEL_URL + "?" + snapshot.revision,
             }
         },
     )
 
     # Also load Browser Mod as a lovelace resource so it's accessible to Cast
     resources = hass.data["lovelace"].resources
-    resourceUrl = FRONTEND_SCRIPT_URL + "?automatically-added" + "&" + version
+    resourceUrl = (
+        FRONTEND_SCRIPT_URL
+        + "?automatically-added"
+        + "&"
+        + snapshot.revision
+    )
     if resources:
         if not resources.loaded:
             await resources.async_load()
@@ -97,7 +173,7 @@ async def async_setup_view(hass: HomeAssistant):
         for r in resources.async_items():
             if r["url"].startswith(FRONTEND_SCRIPT_URL):
                 frontend_added = True
-                if not r["url"].endswith(version):
+                if not r["url"].endswith(snapshot.revision):
                     if isinstance(resources, ResourceStorageCollection):
                         await resources.async_update_item(
                             r["id"], 
@@ -133,7 +209,10 @@ async def async_setup_view(hass: HomeAssistant):
 
 
 async def async_unload_view(hass: HomeAssistant):
-    version = await hass.async_add_executor_job(get_version, hass)
-    remove_extra_js_url(hass, FRONTEND_SCRIPT_URL + "?" + version)
+    frontend_script_url = hass.data[DOMAIN].pop(
+        _DATA_FRONTEND_SCRIPT_URL, None
+    )
+    if frontend_script_url is not None:
+        remove_extra_js_url(hass, frontend_script_url)
     async_remove_panel(hass, FRONTEND_SETTINGS_PANEL_PATH, warn_if_unknown=False)
     async_remove_panel(hass, CONFIG_PANEL_PATH, warn_if_unknown=False)


### PR DESCRIPTION
## Summary

This changes how Browser Mod serves its frontend controller and panel scripts so the frontend follows the lifecycle of the running Python backend.

The three JavaScript files are now captured once for the lifetime of the loaded integration module and served through a `HomeAssistantView`. HACS may replace the integration files on disk, but the running backend continues serving the matching frontend snapshot until Home Assistant restarts.

This addresses the update/cache lifecycle involved in the version-mismatch reports in #1342 without attempting to hot-reload Python code, which Home Assistant does not currently support.

## The problem

A Browser Mod update has two distinct stages:

1. HACS replaces the Python and JavaScript files on disk.
2. Home Assistant restarts and loads the new Python backend.

Reading JavaScript directly from its mutable path during the interval between those stages can expose the new frontend to the old running backend. That produces a legitimate version mismatch.

The previous static handlers have the opposite problem: `cache_headers=True` gives the scripts a long freshness lifetime. A client may continue using an old frontend after the backend restarts if it retains the old resource URL or cached page state.

## Implementation

- Load `browser_mod.js` and both panel scripts into a process-lifetime snapshot.
- Serve the snapshot from memory instead of reading the current files from disk on every request.
- Derive the module URL revision from the runtime version and snapshot contents.
- Return `Cache-Control: no-cache` and a content ETag for each script.
- Return `304 Not Modified` when the client's ETag matches the running snapshot.
- Preserve the existing global frontend-module, panel-module, and Lovelace-resource registrations.
- Register the HTTP view only once per Home Assistant process so a config-entry reload does not attempt to add duplicate routes.
- Remove the exact extra-module URL during config-entry unload rather than rereading a manifest that HACS may already have replaced.

## Update lifecycle

Before an update:

```text
running backend: old
served frontend: old snapshot
files on disk:   old
```

After HACS installs an update but before Home Assistant restarts:

```text
running backend: old
served frontend: old snapshot
files on disk:   new
```

After Home Assistant restarts:

```text
running backend: new
served frontend: new snapshot
files on disk:   new
```

The restart is therefore the synchronization boundary. The frontend and backend exposed by a running Home Assistant process remain a matched pair.

## Cache behavior

`no-cache` still allows browsers to store the scripts, but requires validation before reuse. Unchanged scripts receive a small `304` response. Once a new Home Assistant process loads a new snapshot, its revision and ETags change and clients receive the new content.

The content revision also replaces the previous version-only query value for the controller, panels, and automatically managed Lovelace resource.

## Migration limitation

An origin server cannot retroactively change the headers of a response that a browser already considers fresh. A client holding a script previously served with the long `max-age` may continue using that response until it reloads through the new resource registration or its old cache entry expires.

Likewise, JavaScript already executing in an open page cannot be replaced by an HTTP cache policy. That page must reload after the backend restart. Once a client has loaded the new revision, subsequent Browser Mod updates use the revalidation behavior described above.

This PR is intended to prevent future frontend/backend skew after that one-time transition; it does not claim to remotely invalidate every pre-existing browser cache entry.

## Validation

Completed locally:

- [x] Python compilation
- [x] Ruff validation
- [x] `git diff --check`
- [x] A disk-file replacement does not alter the running frontend snapshot
- [x] Initial requests return `200`, `Cache-Control: no-cache`, and an ETag
- [x] Requests with the matching ETag return `304`
- [x] Unknown script paths return `404`
- [x] Setup -> unload -> setup registers the HTTP view only once
- [x] Existing extra-module, panel-module, and Lovelace-resource paths remain in use

Still to verify before merge:

- [ ] Hassfest
- [ ] Full Home Assistant startup and config-entry reload
- [ ] HACS update without immediate restart continues serving the old snapshot
- [ ] Restart loads the new backend and frontend snapshot together
- [ ] Companion-app/WebView smoke test, including iOS Safari/WebKit

## Scope

The implementation changes only `custom_components/browser_mod/mod_view.py`. It does not change Browser Mod's websocket protocol, version comparison, frontend build, services, entities, or configuration.
